### PR TITLE
fix: do-common v1.4.3

### DIFF
--- a/modules/do-common/Functions/certs.ps1
+++ b/modules/do-common/Functions/certs.ps1
@@ -265,7 +265,9 @@ function Get-CertificateOpenSSL {
         [System.Collections.Generic.List[string]]$cmdArgs = @('s_client')
         $cmdArgs.Add('-connect')
         $cmdArgs.Add("${Uri}:443")
-        $BuildChain ? $cmdArgs.Add('-showcerts') : $null
+        if ($BuildChain) {
+            $cmdArgs.Add('-showcerts')
+        }
     }
 
     process {

--- a/modules/do-common/do-common.psd1
+++ b/modules/do-common/do-common.psd1
@@ -4,7 +4,7 @@
     RootModule           = 'do-common.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '1.4.2'
+    ModuleVersion        = '1.4.3'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Core')


### PR DESCRIPTION
Get-CertificateOpenSSL - returning additional $null value