### PR TITLE
fix: do-linux v0.5.2

### DIFF
--- a/modules/do-linux/Functions/common.ps1
+++ b/modules/do-linux/Functions/common.ps1
@@ -109,7 +109,7 @@ function Invoke-ExecutableBitFix {
 
     # *adding executable bit in files with shebang
     (Get-ChildItem $Path -File -Recurse -Force).Where({
-            $_.DirectoryName -notmatch '/\.git\b' `
+            $_.DirectoryName -notmatch '/\.(git|venv)\b' `
                 -and ($_.Extension -in $ExtensionFilter -or -not $_.Extension) `
                 -and $_.UnixMode -notmatch '^-rwx' `
                 -and (Get-Content $_ -Head 1 | Select-String '^#!' -Quiet)
@@ -122,7 +122,7 @@ function Invoke-ExecutableBitFix {
 
     # *removing executable bit from files without shebang
         (Get-ChildItem $Path -File -Recurse -Force).Where({
-            $_.DirectoryName -notmatch '/\.git\b' `
+            $_.DirectoryName -notmatch '/\.(git|venv)\b' `
                 -and ($_.Extension -in $ExtensionFilter -or -not $_.Extension) `
                 -and $_.UnixMode -match '^-rwx' `
                 -and (Get-Content $_ -Head 1 | Select-String '^#!' -NotMatch -Quiet)

--- a/modules/do-linux/do-linux.psd1
+++ b/modules/do-linux/do-linux.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'do-linux.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.5.1'
+    ModuleVersion        = '0.5.2'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
Invoke-ExecutableBitFix - exclude .venv dir