### PR TITLE
refactor: aliases-kubectl v0.11.1

### DIFF
--- a/modules/aliases-kubectl/Functions/internal.ps1
+++ b/modules/aliases-kubectl/Functions/internal.ps1
@@ -72,12 +72,8 @@ The command allows to create functions with autocompletion for specific kubectl 
 The kubectl operation to be performed. Valid values are 'get', 'describe', and 'delete'.
 .PARAMETER Kind
 The kind of kubernetes object to be operated on. Valid values are 'Pod', 'Service', 'Namespace', and 'Secret'.
-.PARAMETER Pod
-The name of the Pod to be operated on. Mandatory for 'Pod' kind.
-.PARAMETER Service
-The name of the Service to be operated on. Mandatory for 'Service' kind.
-.PARAMETER Secret
-The name of the Secret to be operated on. Mandatory for 'Secret' kind.
+.PARAMETER Name
+The name of the resource to be operated on. Optional parameter.
 .PARAMETER Namespace
 The namespace in which the operation should be performed. Optional parameter.
 .PARAMETER Xargs
@@ -98,19 +94,11 @@ function Build-KubectlCommand {
         [ValidateSet('Pod', 'Service', 'Namespace', 'Secret')]
         [string[]]$Kind,
 
-        [Parameter(Mandatory, ParameterSetName = 'pod')]
-        [string]$Pod,
+        [Parameter(Position = 0)]
+        [string]$Name,
 
-        [Parameter(Mandatory, ParameterSetName = 'service')]
-        [string]$Service,
-
-        [Parameter(Mandatory, ParameterSetName = 'secret')]
-        [string]$Secret,
-
-        [Parameter(Mandatory, ParameterSetName = 'namespace')]
-        [Parameter(ParameterSetName = 'pod')]
-        [Parameter(ParameterSetName = 'service')]
-        [Parameter(ParameterSetName = 'secret')]
+        [Parameter(ParameterSetName = 'namespace')]
+        [Parameter(ParameterSetName = 'Default')]
         [string]$Namespace,
 
         [string[]]$Xargs,
@@ -130,16 +118,11 @@ function Build-KubectlCommand {
         @('Verb', 'Kind').ForEach({ $PSBoundParameters.Remove($_) | Out-Null })
 
         # build parameters
-        if ($PSBoundParameters.Pod) {
-            $cmnd.Add($Pod)
-            $PSBoundParameters.Remove('Pod') | Out-Null
-        } elseif ($PSBoundParameters.Service) {
-            $cmnd.Add($Service)
-            $PSBoundParameters.Remove('Service') | Out-Null
-        } elseif ($PSBoundParameters.Secret) {
-            $cmnd.Add($Secret)
-            $PSBoundParameters.Remove('Secret') | Out-Null
+        if ($PSBoundParameters.Name) {
+            $cmnd.Add($Name)
+            $PSBoundParameters.Remove('Name') | Out-Null
         }
+
         if ($PSBoundParameters.Namespace) {
             if ($Kind -ne 'Namespace') {
                 $cmnd.AddRange([string[]]@('--namespace', $Namespace))

--- a/modules/aliases-kubectl/Functions/pods.ps1
+++ b/modules/aliases-kubectl/Functions/pods.ps1
@@ -3,7 +3,7 @@
 .SYNOPSIS
 Get kubernetes pod(s).
 
-.PARAMETER Pod
+.PARAMETER Name
 Name of the pod.
 .PARAMETER Namespace
 Specify namespace of the pod.
@@ -13,7 +13,7 @@ function kgpo {
     param (
         [Parameter(Position = 0)]
         [ArgumentCompleter({ ArgK8sGetPods @args })]
-        [string]$Pod,
+        [string]$Name,
 
         [ArgumentCompleter({ ArgK8sGetNamespaces @args })]
         [string]$Namespace,
@@ -41,7 +41,7 @@ function kdpo {
     param (
         [Parameter(Position = 0)]
         [ArgumentCompleter({ ArgK8sGetPods @args })]
-        [string]$Pod,
+        [string]$Name,
 
         [ArgumentCompleter({ ArgK8sGetNamespaces @args })]
         [string]$Namespace,
@@ -69,7 +69,7 @@ function kgpocntr {
     param (
         [Parameter(Position = 0, Mandatory)]
         [ArgumentCompleter({ ArgK8sGetPods @args })]
-        [string]$Pod,
+        [string]$Name,
 
         [ArgumentCompleter({ ArgK8sGetNamespaces @args })]
         [string]$Namespace,

--- a/modules/aliases-kubectl/Functions/secrets.ps1
+++ b/modules/aliases-kubectl/Functions/secrets.ps1
@@ -3,7 +3,7 @@
 .SYNOPSIS
 Get kubernetes secret(s).
 
-.PARAMETER Secret
+.PARAMETER Name
 Name of the secret. Optional parameter. If not specified, all secrets in the namespace will be returned.
 .PARAMETER Namespace
 Specify namespace of the pod. Optional parameter.
@@ -19,7 +19,7 @@ function kgsec {
     param (
         [Parameter(Position = 0)]
         [ArgumentCompleter({ ArgK8sGetSecrets @args })]
-        [string]$Secret,
+        [string]$Name,
 
         [ArgumentCompleter({ ArgK8sGetNamespaces @args })]
         [string]$Namespace,
@@ -46,7 +46,7 @@ function kgsec {
 .SYNOPSIS
 Decode and print kubernetes secret data.
 
-.PARAMETER Secret
+.PARAMETER Name
 Name of the secret to be decoded. Mandatory parameter.
 .PARAMETER Namespace
 Specify namespace of the secret. Optional parameter.
@@ -62,7 +62,7 @@ function Get-KubectlSecretDecodedData {
     param (
         [Parameter(Mandatory, Position = 0)]
         [ArgumentCompleter({ ArgK8sGetSecrets @args })]
-        [string]$Secret,
+        [string]$Name,
 
         [ArgumentCompleter({ ArgK8sGetNamespaces @args })]
         [string]$Namespace,

--- a/modules/aliases-kubectl/aliases-kubectl.psd1
+++ b/modules/aliases-kubectl/aliases-kubectl.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'aliases-kubectl.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '0.11.0'
+    ModuleVersion        = '0.11.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
Build-KubectlCommand more generic by using a name parameter instead of resource kind specific one.