### PR TITLE
feat(do-common): certificate host:port support and cleaner error handling

### DIFF
--- a/.claude/skills/second-opinion/REVIEW-BRIEF.md
+++ b/.claude/skills/second-opinion/REVIEW-BRIEF.md
@@ -1,0 +1,121 @@
+---
+repo: szymonos/ps-modules
+---
+
+# Review brief
+
+Curated context for a heterogeneous-model reviewer (`/second-opinion`).
+You are reviewing a code diff. Read this brief first, then the diff, then any files needed for context.
+
+## Project
+
+A collection of cross-platform PowerShell modules, plus the tooling that packages and documents them. Four concerns
+in one repo:
+
+1. **PowerShell modules** (`modules/<name>/`) - the primary content. Seven modules:
+   `aliases-git`, `aliases-kubectl` (composable `git`/`gh` and `kubectl` alias functions),
+   `do-az` (Azure: subscriptions, Key Vault, AKS, Resource Graph, MS Graph),
+   `do-common` (cross-platform, dependency-free: encoding, certs, Python venvs, shell helpers, networking),
+   `do-linux`, `do-win` (OS-specific utilities), `psm-windows`.
+2. **Python pre-commit hooks** (`src/hooks/`) - `align_tables.py`, `gremlins.py`, `validate_docs_words.py`.
+3. **Agent skills** (`.claude/skills/`) - Claude Code slash commands with bundled Python/bash helper scripts.
+4. **Docs** (`docs/`) - one folder per module, published as a static site via `mkdocs-material`
+   (`mkdocs build --strict`).
+
+Tooling: `make` is the entry point, `uv` manages Python deps, `prek` runs the pre-commit hooks. Modules are
+installed/scaffolded via `module_manage.ps1`. Requires PowerShell 7+.
+
+## Module layout and invariants
+
+Each module is `modules/<name>/` with:
+
+- `<name>.psd1` - manifest; `FunctionsToExport` and `AliasesToExport` lists.
+- `<name>.psm1` - root module; dot-sources every `Functions/*.ps1`, then `Export-ModuleMember` with an
+  explicit `Function` + `Alias` list.
+- `Functions/*.ps1` - the actual function definitions.
+
+**Three-file sync invariant (highest-value thing to check).** Adding, renaming, or removing a public function
+or alias must be reflected in all three places, or the module ships broken:
+
+1. the function body in `Functions/<file>.ps1`,
+2. the export list in `<name>.psm1` (plus a `. $PSScriptRoot/Functions/<file>.ps1` dot-source line if the file is new),
+3. `FunctionsToExport` / `AliasesToExport` in `<name>.psd1`.
+
+A function present in a psd1/psm1 export list but not defined (or vice versa), a new `Functions/*.ps1` file that
+`<name>.psm1` never dot-sources, or a `Set-Alias` whose alias is missing from the export lists - all are real bugs.
+
+**Docs correspondence.** Each module's public surface is documented under `docs/<module>/`. A new/renamed/removed
+public function usually needs a matching docs edit; a diff that changes exports but not docs is worth a `warning`.
+
+## Focus areas (ordered by importance)
+
+1. **PowerShell correctness** - logic errors in module functions. Watch for: pipeline `begin`/`process`/`end`
+   misuse (per-item work in `begin`), unhandled `$null`, missing `[CmdletBinding()]`/`param` blocks, wrong
+   `ParameterSetName` wiring, `$PSBoundParameters` splatting that forwards params the callee doesn't accept,
+   undisposed `IDisposable` objects (streams, TCP clients), swallowed errors, and `Throw`/`Write-Error` where a
+   terminating `$PSCmdlet.ThrowTerminatingError(...)` would give a cleaner call site. Verify string interpolation,
+   regex, and `-match`/`-replace` patterns.
+2. **Export / manifest integrity** - the three-file sync invariant above. Also `#Requires` statements and
+   `RequiredModules` in manifests that don't match actual usage.
+3. **Alias-function pattern** - alias modules (`aliases-git`, `aliases-kubectl`) build on `Invoke-WriteExecCommand`
+   (see `Functions/internal.ps1`), which prints the command then runs it. Check that `-WhatIf`/`-Quiet` parameter
+   sets are wired correctly and `[Parameter(ValueFromRemainingArguments)]$Xargs` is present unless the command
+   takes no extra args.
+4. **Python correctness** - logic errors in `src/hooks/` and `.claude/skills/*/scripts/`. Type safety, edge cases,
+   unchecked returns, subprocess error handling, regex bugs, unintended file mutation.
+5. **Skill design** - `SKILL.md` instructions that contradict each other, reference non-existent files/commands,
+   use wrong phase numbers, or create circular skill dependencies.
+6. **Docs & Markdown** - broken tables (mismatched columns), unclosed fenced code blocks, heading hierarchy
+   violations, and content that breaks `mkdocs build --strict` (bad relative links, missing nav targets).
+
+## Known patterns - do NOT flag
+
+These are deliberate. Flagging them is noise:
+
+- **`prek` instead of `pre-commit`** - `prek` is the pre-commit runner used in this project (via `make lint`).
+- **ASCII-only punctuation (hyphens, not em/en dashes; straight quotes)** - enforced by `src/hooks/gremlins.py`,
+  which rejects em dashes, smart quotes, non-breaking spaces, etc. Plain `-` in prose is correct, not a typo.
+- **`validate_docs_words.py` rewriting `project-words.txt`** - the hook intentionally prunes unused words and
+  writes back a sorted, lowercased, deduplicated list. Mutating that file is the hook's job, not a bug.
+- **Aligned Markdown tables** - the `align-tables` hook (MD060) auto-formats tables so every row's pipes share a
+  column. Pre-existing alignment is machine-generated; don't flag column padding as a style issue.
+- **`disable-model-invocation` in skill frontmatter** - controls whether a skill can be invoked programmatically
+  by other skills. Intentional per-skill setting, not stale metadata.
+- **`--no-custom-instructions` / `--allow-all-tools` in the second-opinion skill** - deliberate; see its SKILL.md
+  rationale (process-boundary bias control).
+- **`ubuntu-slim` as a GitHub Actions runner** - valid GitHub-hosted runner, used intentionally.
+- **`REVIEW-BRIEF.md` with `repo:` frontmatter tag** - portability mechanism; not stale metadata.
+- **Explicit per-module `Export-ModuleMember` lists** (rather than `Functions/*` wildcards) - intentional; keeps
+  the public surface auditable and matches `FunctionsToExport` in the manifest.
+- **`Invoke-Expression` inside `Invoke-WriteExecCommand`** - intentional design of the alias modules (the command
+  string is printed then executed); not an injection oversight in this context.
+
+## Output format
+
+Produce a single markdown response with this structure:
+
+```text
+## Findings
+
+### F-001 - <severity> - <file>:<line>
+<one-paragraph description; reference the constraint being violated; be specific>
+
+**Suggestion:** <concrete fix direction, NOT a patch>
+
+### F-002 - <severity> - <file>:<line>
+...
+```
+
+Severities:
+
+- **`bug`** - correctness or security defect; the code is wrong.
+- **`warning`** - likely issue, needs judgment; the code might be wrong under conditions you can't fully verify.
+- **`nit`** - style or clarity; the code works but could be clearer.
+
+If zero findings, output exactly: `No findings.`
+
+## Bias-control rules
+
+- Speculate carefully. If you suspect a bug but can't verify the call site, mark `warning` not `bug`.
+- Don't pad with `nit` findings to look productive. Five `nit` items on a 200-line diff is fine; thirty is noise.
+- If several findings share the same root cause, consolidate into one finding with multiple `<file>:<line>` references.

--- a/.claude/skills/second-opinion/SKILL.md
+++ b/.claude/skills/second-opinion/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: second-opinion
+description: Heterogeneous-model code review of the current branch's changes. Invokes GitHub Copilot CLI with gpt-5.3-codex to review git diff since merge-base with the repo's trunk branch (or user-specified commit). Reads .claude/skills/second-opinion/REVIEW-BRIEF.md for focused project context. Returns structured findings that Claude reads, summarizes, and acts on. Use when the user types `/second-opinion`, asks for a second opinion on a branch, wants GPT to review the work, or wants an independent review before pushing.
+disable-model-invocation: false
+---
+
+# Second opinion
+
+Heterogeneous-model author-time review of the current branch. Runs **GitHub Copilot CLI** (`copilot`) with a
+GPT-family model (default `gpt-5.3-codex`) against the diff since `git merge-base "$TRUNK_REF" HEAD`, where
+`$TRUNK_REF` is a resolvable git ref for the repo's default branch - either a local branch (`main`) or a
+remote-tracking ref (`origin/main`), resolved in Phase 1. The reviewer returns structured findings; Claude reads
+them and acts.
+
+The bias-control mechanism is **the process boundary itself**. Copilot runs as a separate binary, with a separate
+model family, returning only text. Claude (the implementer) cannot influence Copilot's review; Copilot cannot edit
+code. Tool restriction inside Copilot is unnecessary - the architecture enforces the separation.
+
+## When to use
+
+- `/second-opinion` - review current branch vs. `git merge-base "$TRUNK_REF" HEAD` (trunk autodetected in Phase 1;
+  works for both local and remote-only checkouts)
+- `/second-opinion <commit>` - review since an arbitrary commit hash
+- `/second-opinion --model <id>` - use a different Copilot model
+- "Get a second opinion before I push" / "have GPT review this" - same as `/second-opinion`
+
+## Prerequisites
+
+`copilot` CLI installed and authenticated. Verify with `command -v copilot >/dev/null && copilot --version`. If
+missing, surface to the user: install via `https://gh.io/copilot-install` and run `copilot login`. Updates via
+`copilot update`.
+
+## Workflow
+
+### Phase 0 - verify review brief
+
+Run the bundled check script to verify `REVIEW-BRIEF.md` targets this repo:
+
+```bash
+python3 <skill-path>/scripts/review_brief.py check
+```
+
+Returns JSON with `match`, `brief_repo`, `current_repo`, `needs_update`.
+
+- **Match** → proceed to Phase 1.
+- **Mismatch or missing `repo:` tag** → run discovery and offer a one-time rewrite:
+
+  ```bash
+  python3 <skill-path>/scripts/review_brief.py discover
+  ```
+
+  The discovery output includes detected stacks, context from `CLAUDE.md`/`AGENTS.md`/`README.md`, and the
+  existing brief content. Use this context to rewrite `REVIEW-BRIEF.md` with:
+  - Updated `repo:` frontmatter tag matching the current repo
+  - Project description derived from the discovered context
+  - Focus areas appropriate for the detected tech stack
+  - Empty "Known patterns - do NOT flag" section (compounding loop will fill it)
+  - Same output format and bias-control rules (these are repo-agnostic)
+
+  Present the rewrite to the user via `AskUserQuestion` ("Update REVIEW-BRIEF.md for this repo?"). On approval,
+  write the file. On decline, proceed with the existing brief (it may produce noisy or irrelevant findings).
+
+This phase runs once per repo. After the brief is updated, `check` returns `match: true` on all subsequent runs.
+
+### Phase 1 - resolve the diff base
+
+This skill is portable across repos that use `main`, `master`, `trunk`, `prod`, etc. - never assume `main`.
+Resolve `$TRUNK_REF` to a git ref that's guaranteed to exist locally (a local branch OR a remote-tracking ref -
+many CI environments only have the trunk at `refs/remotes/origin/<name>`), then merge-base against it:
+
+```bash
+# Detect the trunk name (zero-network first, then fallbacks)
+TRUNK_NAME=""
+ref="$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)" && TRUNK_NAME="${ref#origin/}"
+[ -n "$TRUNK_NAME" ] || TRUNK_NAME="$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null)"
+[ -n "$TRUNK_NAME" ] || for c in main master trunk prod; do
+  git show-ref --verify --quiet "refs/heads/$c" && TRUNK_NAME="$c" && break
+  git show-ref --verify --quiet "refs/remotes/origin/$c" && TRUNK_NAME="$c" && break
+done
+[ -n "$TRUNK_NAME" ] || { echo "Could not resolve trunk; run: git remote set-head origin -a" >&2; exit 1; }
+
+# Resolve to a usable git ref (prefer local branch, fall back to remote)
+if git show-ref --verify --quiet "refs/heads/$TRUNK_NAME"; then
+  TRUNK_REF="$TRUNK_NAME"
+elif git show-ref --verify --quiet "refs/remotes/origin/$TRUNK_NAME"; then
+  TRUNK_REF="origin/$TRUNK_NAME"
+else
+  echo "Trunk '$TRUNK_NAME' has no local or remote ref; run: git fetch origin $TRUNK_NAME" >&2; exit 1
+fi
+
+# Default: merge-base with trunk
+base="$(git merge-base "$TRUNK_REF" HEAD)"
+
+# Alternative: a user-specified commit from skill args overrides the default.
+# Uncomment and substitute when the caller passed an explicit base ref:
+# base="<user-arg>"
+```
+
+Each fallback is gated on the previous one having actually produced a value - **never collapse the `symbolic-ref`
+step into a `git symbolic-ref ... | sed ...` pipeline**, because `sed` always exits 0 even when the upstream
+`git symbolic-ref` failed, so the `||` chain wouldn't trigger. The block always re-resolves `TRUNK_REF` from
+scratch every time it runs - it does not check for or respect a pre-existing `$TRUNK_REF` in the environment. If a
+caller has already resolved trunk, the re-resolution returns the same value (so re-running is safe and produces no
+surprises), but it does *run* every time; it's not skipped.
+
+If `base == HEAD`, exit early: "Nothing to review - branch is at parity with the base." Don't invoke Copilot.
+
+**Caller contract: review scope is committed state only.** Uncommitted working-tree changes are invisible to
+`git diff <base>..HEAD` and therefore invisible to the reviewer. Callers that need to review uncommitted work (a
+branch with WIP in the working tree but no commits ahead of the base) must create a throwaway WIP commit *before*
+invoking this skill, then dispose of it after via their own flow (e.g., `git reset --soft <base>`). This skill will
+not silently degrade by reviewing the working tree - the process boundary that gives Copilot its bias-control also
+means it only sees what `git` shows it.
+
+### Phase 2 - invoke Copilot
+
+Single Bash call. The prompt tells Copilot to read the brief, run `git diff` itself, and produce findings in the
+brief's specified format:
+
+```bash
+copilot -p "Read .claude/skills/second-opinion/REVIEW-BRIEF.md, then review the current branch's changes since <base>. Run: git diff <base>..HEAD to see all changes. Read referenced files for context as needed. Output findings using the format and severities specified in the brief." \
+  -s \
+  --model gpt-5.3-codex \
+  --no-custom-instructions \
+  --allow-all-tools
+```
+
+Flag rationale:
+
+- **`-s`** (silent) - strips UI chrome, leaves only the agent's response on stdout. Critical for parsing.
+- **`--no-custom-instructions`** - skips `AGENTS.md` and `.claude/skills/` auto-loading. The curated
+  `REVIEW-BRIEF.md` is the only context Copilot needs. Loading everything would burn attention budget on irrelevant
+  context.
+- **`--allow-all-tools`** - required for non-interactive `-p` mode. Safe here: Copilot's output is text-only back
+  to Claude; any edits Copilot might attempt happen in its process, not Claude's. Even if Copilot wrote a file,
+  Claude would not act on it - Claude only acts on the findings text.
+- **`--model gpt-5.3-codex`** - default. Override via skill arg (see model override below).
+
+If Copilot exits non-zero, capture the error and surface to the user. Don't retry automatically.
+
+### Phase 3 - parse and act on findings
+
+Save Copilot's raw output to a temp file and parse it with the bundled script:
+
+```bash
+python3 <skill-path>/scripts/review_brief.py parse /tmp/copilot-review.md
+```
+
+Returns JSON: `{"findings": [{id, severity, file, line, description, suggestion}, ...], "count": N}`. If count is
+0, announce "No findings." and exit.
+
+#### Output handling
+
+Two modes, selected by the caller via context (the skill itself doesn't need to know who called it):
+
+**Interactive mode** (default - standalone `/second-opinion`):
+
+1. Present a summary table to the user. Header `## Copilot review (gpt-5.3-codex) - N findings`, then a Markdown
+   table with columns `ID | Severity | Location | Summary` - one row per finding, e.g. `F-001 | bug |
+   src/main.py:142 | <one-line summary>`.
+2. Ask via `AskUserQuestion` which to act on. For ≤4 findings, use one question with multiSelect options (`F-001`,
+   `F-002`, ...). For more, present in chunks of 4 or ask "fix all bugs, triage warnings/nits?" first.
+3. For each finding the user wants fixed: Claude reads the relevant file, formulates a fix from Copilot's
+   `Suggestion`, applies it via `Edit`. **Do not copy Copilot's patch verbatim** - Copilot suggests direction;
+   Claude writes the actual edit using its own knowledge of the codebase.
+4. After edits, run `make lint` to validate.
+
+**Automated mode** (when invoked by another skill as a pre-push review gate):
+
+1. Auto-fix findings with `severity: bug` AND a concrete `Suggestion` that maps cleanly to one or two lines of
+   code. No user prompt needed for these - they're obvious corrections.
+2. Surface to the user via `AskUserQuestion`:
+   - Any `bug` finding where the fix is non-obvious or spans multiple files.
+   - All `warning` findings (by definition, judgment is needed).
+   - `nit` findings only if the user explicitly opted in (default: skip nits - they're not blockers).
+3. After resolution, re-run `make lint` to validate.
+4. Return control to the caller. Review-driven fixes are uncommitted working-tree changes - the caller decides how
+   to commit them.
+
+The caller selects automated mode by passing findings context (e.g., "act on findings per automated mode").
+Without that context, the skill defaults to interactive mode.
+
+## Model override
+
+Pass `--model <id>` in the skill args. Claude extracts it and substitutes for `gpt-5.3-codex` in the Copilot
+invocation.
+
+Currently available Copilot models (May 2026 - list with `copilot -p "list available models"`):
+
+| Model ID          | Tier       | Notes                                                                                                                              |
+| ----------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `gpt-5.3-codex`   | standard   | **Default** - code-focused, balanced cost                                                                                          |
+| `gpt-5.2-codex`   | standard   | Older codex; use only if 5.3 unavailable                                                                                           |
+| `gpt-5.5`         | premium    | Heavier; use for complex / security-sensitive diffs                                                                                |
+| `gpt-5.4`         | standard   | General-purpose; less code-specialized than codex variants                                                                         |
+| `gpt-5-mini`      | fast/cheap | Quick triage; expect more noise / missed nuance                                                                                    |
+| `claude-opus-4-7` | premium    | **NOT heterogeneous** - same family as Claude (the implementer); only useful if you specifically want a same-family second context |
+
+## Anti-patterns
+
+- **Running `/second-opinion` repeatedly on the same diff.** Wastes Copilot API tokens. If the first run missed
+  something, evolve `REVIEW-BRIEF.md` (add a focus area), don't re-run.
+- **Dropping `--no-custom-instructions`.** Copilot would auto-load `AGENTS.md` and every file under
+  `.claude/skills/`. That's hundreds of lines of context unrelated to the actual diff review.
+- **Piping the full diff into the `-p` argument.** Copilot's shell access lets it run `git diff` itself - piping
+  risks shell-escape issues and prompt-size limits. Let Copilot run the command.
+- **Copying Copilot's patch verbatim.** Copilot's `Suggestion` is a direction; Claude writes the actual edit.
+  Verbatim copies skip Claude's knowledge of the codebase's idiomatic patterns and accepted decisions.
+- **Adding `Co-Authored-By: Copilot` to fix commits.** Fixes derived from Copilot's review are Claude's edits
+  informed by Copilot's review - same as a human reviewer's comment. No tooling attribution needed.
+- **Running `/second-opinion` after a destructive history rewrite (soft-reset).** Review-driven fixes after a
+  soft-reset need a second reset cycle to re-cut clean commits. Run the review *before* any history rewrite so
+  fixes land in the WIP state and get consolidated for free.
+
+## Example invocations
+
+- `/second-opinion` - review against `git merge-base "$TRUNK_REF" HEAD` (trunk autodetected in Phase 1; works for
+  both local and remote-only checkouts)
+- `/second-opinion abc1234` - review against an arbitrary commit
+- `/second-opinion --model gpt-5.5` - use a heavier model for a security-sensitive branch
+- "Get a second opinion before I push" - same as `/second-opinion`
+
+## Compounding loop
+
+`REVIEW-BRIEF.md` is **git-tracked** so it compounds across runs. Two triggers update it:
+
+1. **Copilot keeps flagging an intentional pattern** → add it to the "do NOT flag" section.
+2. **Copilot misses a class of bug repeatedly** → add the relevant focus area or paired-file mapping.

--- a/.claude/skills/second-opinion/scripts/review_brief.py
+++ b/.claude/skills/second-opinion/scripts/review_brief.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env -S uv run python3
+"""
+Review brief management for the /second-opinion skill.
+
+Three subcommands:
+  check    - verify REVIEW-BRIEF.md repo tag matches current repo
+  discover - scan repo for context to generate/update the brief
+  parse    - parse Copilot's raw output into structured JSON findings
+
+Usage:
+    python3 scripts/review_brief.py check
+    python3 scripts/review_brief.py discover
+    python3 scripts/review_brief.py parse <raw-output-file>
+    echo "<copilot output>" | python3 scripts/review_brief.py parse -
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+BRIEF_FILENAME = "REVIEW-BRIEF.md"
+CONTEXT_FILES = [
+    ("claude_md", "CLAUDE.md"),
+    ("agents_md", "AGENTS.md"),
+    ("architecture_md", "ARCHITECTURE.md"),
+    ("readme", "README.md"),
+    ("contributing", "CONTRIBUTING.md"),
+]
+SKIP_DIRS = {
+    ".git",
+    "node_modules",
+    "dist",
+    "build",
+    "target",
+    ".venv",
+    "venv",
+    "vendor",
+    "__pycache__",
+    "site",
+}
+MAX_CONTEXT_LINES = 80
+
+
+def _find_brief(start: Path | None = None) -> Path | None:
+    """Walk up from start to find REVIEW-BRIEF.md."""
+    if start is None:
+        start = Path(__file__).resolve().parent.parent
+    brief = start / BRIEF_FILENAME
+    if brief.exists():
+        return brief
+    for parent in start.parents:
+        candidate = parent / ".claude" / "skills" / "second-opinion" / BRIEF_FILENAME
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _read_frontmatter(path: Path) -> dict[str, str]:
+    """Extract YAML frontmatter key-value pairs from a markdown file."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    fm = text[4:end]
+    result: dict[str, str] = {}
+    for line in fm.splitlines():
+        if ":" in line:
+            key, _, value = line.partition(":")
+            result[key.strip()] = value.strip().strip('"').strip("'")
+    return result
+
+
+def _get_current_repo() -> str | None:
+    """Get current repo's nameWithOwner via gh CLI."""
+    try:
+        result = subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
+def _read_head(path: Path, max_lines: int = MAX_CONTEXT_LINES) -> str | None:
+    """Read up to max_lines from a file, or None if it doesn't exist."""
+    if not path.exists():
+        return None
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        return "\n".join(lines[:max_lines])
+    except OSError:
+        return None
+
+
+def _has_file_with_suffix(root: Path, suffix: str) -> bool:
+    """True if any file with *suffix* exists under root, skipping SKIP_DIRS."""
+    for path in root.rglob(f"*{suffix}"):
+        if not any(part in SKIP_DIRS for part in path.relative_to(root).parts):
+            return True
+    return False
+
+
+def _detect_stacks(root: Path) -> list[str]:
+    """Quick stack detection (subset of bootstrap-hooks/detect_stack.py)."""
+    stacks: list[str] = []
+    markers = {
+        "python": ["pyproject.toml", "requirements.txt", "setup.py"],
+        "javascript": ["package.json"],
+        "go": ["go.mod"],
+        "rust": ["Cargo.toml"],
+        "java": ["pom.xml", "build.gradle"],
+        "ruby": ["Gemfile"],
+        "docker": ["Dockerfile", "docker-compose.yml"],
+        "terraform": [],
+        "mkdocs": ["mkdocs.yml", "mkdocs.yaml"],
+    }
+    for stack, files in markers.items():
+        for f in files:
+            if (root / f).exists():
+                stacks.append(stack)
+                break
+
+    if _has_file_with_suffix(root, ".tf"):
+        stacks.append("terraform")
+    if _has_file_with_suffix(root, ".sh"):
+        stacks.append("shell")
+    if (root / ".obsidian").exists() or any(
+        (root / "docs").rglob(".obsidian") if (root / "docs").exists() else []
+    ):
+        stacks.append("obsidian")
+    if (root / "docs").exists() and any((root / "docs").rglob("*.md")):
+        stacks.append("markdown-docs")
+    if (root / ".github" / "workflows").exists():
+        stacks.append("github-actions")
+    if (root / ".gitlab-ci.yml").exists():
+        stacks.append("gitlab-ci")
+
+    return sorted(set(stacks))
+
+
+# -- Subcommands --------------------------------------------------------------
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    """Check if REVIEW-BRIEF.md repo tag matches current repo."""
+    root = Path(args.repo_root).resolve()
+    brief_path = _find_brief(root / ".claude" / "skills" / "second-opinion")
+
+    result: dict = {
+        "brief_exists": brief_path is not None and brief_path.exists(),
+        "brief_repo": None,
+        "current_repo": None,
+        "match": False,
+        "needs_update": False,
+    }
+
+    if not result["brief_exists"]:
+        result["needs_update"] = True
+        result["reason"] = "REVIEW-BRIEF.md not found"
+        json.dump(result, sys.stdout, indent=2)
+        print()
+        return 1
+
+    fm = _read_frontmatter(brief_path)
+    result["brief_repo"] = fm.get("repo")
+    result["current_repo"] = _get_current_repo()
+
+    if result["brief_repo"] is None:
+        result["needs_update"] = True
+        result["reason"] = "No repo: tag in REVIEW-BRIEF.md frontmatter"
+    elif result["current_repo"] is None:
+        result["needs_update"] = False
+        result["reason"] = "Could not determine current repo (gh CLI unavailable?)"
+    elif result["brief_repo"] == result["current_repo"]:
+        result["match"] = True
+    else:
+        result["needs_update"] = True
+        brief = result["brief_repo"]
+        current = result["current_repo"]
+        result["reason"] = (
+            f"Repo mismatch: brief targets '{brief}', current is '{current}'"
+        )
+
+    json.dump(result, sys.stdout, indent=2)
+    print()
+    return 0 if result["match"] else 1
+
+
+def cmd_discover(args: argparse.Namespace) -> int:
+    """Scan repo for context to generate/update the brief."""
+    root = Path(args.repo_root).resolve()
+
+    context_files: dict[str, str | None] = {}
+    for key, filename in CONTEXT_FILES:
+        context_files[key] = _read_head(root / filename)
+
+    stacks = _detect_stacks(root)
+    current_repo = _get_current_repo()
+
+    brief_path = _find_brief(root / ".claude" / "skills" / "second-opinion")
+    existing_brief = None
+    if brief_path and brief_path.exists():
+        existing_brief = brief_path.read_text(encoding="utf-8", errors="replace")
+
+    result = {
+        "repo": current_repo,
+        "root": str(root),
+        "stacks": stacks,
+        "context_files": {k: v for k, v in context_files.items() if v is not None},
+        "existing_brief": existing_brief,
+    }
+
+    json.dump(result, sys.stdout, indent=2)
+    print()
+    return 0
+
+
+def cmd_parse(args: argparse.Namespace) -> int:
+    """Parse Copilot's raw markdown output into structured JSON findings."""
+    if args.input == "-":
+        raw = sys.stdin.read()
+    else:
+        raw = Path(args.input).read_text(encoding="utf-8", errors="replace")
+
+    if "No findings." in raw and "### F-" not in raw:
+        json.dump({"findings": [], "count": 0}, sys.stdout, indent=2)
+        print()
+        return 0
+
+    finding_re = re.compile(
+        r"###\s+(F-\d+)\s*-\s*(bug|warning|nit)\s*-\s*(.+?)(?::(\d+))?\s*\n"
+        r"(.*?)(?=\n###\s+F-|\n##\s|\Z)",
+        re.DOTALL,
+    )
+
+    findings: list[dict] = []
+    for m in finding_re.finditer(raw):
+        body = m.group(5).strip()
+
+        suggestion = None
+        suggestion_match = re.search(
+            r"\*\*Suggestion:\*\*\s*(.+?)(?=\n\n|\n###|\Z)", body, re.DOTALL
+        )
+        if suggestion_match:
+            suggestion = suggestion_match.group(1).strip()
+            description = body[: suggestion_match.start()].strip()
+        else:
+            description = body
+
+        finding: dict = {
+            "id": m.group(1),
+            "severity": m.group(2),
+            "file": m.group(3).strip(),
+            "description": description,
+        }
+        if m.group(4):
+            finding["line"] = int(m.group(4))
+        if suggestion:
+            finding["suggestion"] = suggestion
+
+        findings.append(finding)
+
+    json.dump({"findings": findings, "count": len(findings)}, sys.stdout, indent=2)
+    print()
+    return 0
+
+
+def main() -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Review brief management")
+    parser.add_argument(
+        "--repo-root", default=".", help="Repository root (default: cwd)"
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("check", help="Verify REVIEW-BRIEF.md repo tag matches current repo")
+    sub.add_parser(
+        "discover", help="Scan repo for context to generate/update the brief"
+    )
+
+    parse_p = sub.add_parser("parse", help="Parse Copilot output into JSON findings")
+    parse_p.add_argument("input", help="Path to raw output file, or '-' for stdin")
+
+    args = parser.parse_args()
+
+    commands = {
+        "check": cmd_check,
+        "discover": cmd_discover,
+        "parse": cmd_parse,
+    }
+    return commands[args.command](args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
         language: system
         types: [text]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
+    rev: v0.15.20
     hooks:
       - id: ruff-check
         types_or: [python, pyi]
@@ -46,13 +46,13 @@ repos:
       - id: trailing-whitespace
         exclude: \.md$
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.22.0
+    rev: v0.23.0
     hooks:
       - id: markdownlint-cli2
         files: \.md$
         exclude: /copilot-instructions\.md
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v9.7.0
+    rev: v10.0.1
     hooks:
       - id: cspell
         files: (README|docs/.+)\.md$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,112 +1,43 @@
-# AGENTS.md
+# ps-modules
 
-## Tooling
+Cross-platform PowerShell modules, plus the MkDocs site and Python tooling that document and
+lint them.
 
-- **Primary interface**: `make` (Makefile) - run `make` to see available targets
-- **Package manager**: `uv` (not pip/poetry) - see <https://docs.astral.sh/uv/llms.txt>
-- **Linting**: `make lint` runs pre-commit hooks via `prek` (not pre-commit).
-  Hooks are configured in `.pre-commit-config.yaml` and include: `ruff` (Python),
-  `markdownlint-cli2` (Markdown), `cspell` (spelling), `mkdocs build --strict`,
-  gremlins check, and docs word validation. Do not run these tools individually.
-- **Docs**: `mkdocs` with Material theme (`make mkdocs-serve` to preview)
+## Compound knowledge
 
-## IMPORTANT: Always Validate Changes
+Two knowledge layers beyond this file. Read on demand, not upfront:
 
-After every code or documentation change, run `make lint` and fix all failures before proceeding.
-Do not skip this step. Do not assume changes are correct without running lint.
+| Layer                                    | When to read                                               | What it answers        |
+| ---------------------------------------- | ---------------------------------------------------------- | ---------------------- |
+| [`ARCHITECTURE.md`](ARCHITECTURE.md)     | Modifying module structure, hooks, skills, build pipeline  | How things connect     |
+| [`design/lessons.md`](design/lessons.md) | Fixing bugs, repeating a mistake, touching hooks or skills | What went wrong before |
 
-## Project Structure
+Skip both for content-only edits to existing docs, typo fixes, and conversational questions.
 
-```text
-modules/<name>/
-  <name>.psd1          # manifest (FunctionsToExport, AliasesToExport)
-  <name>.psm1          # root module (dot-sources, Export-ModuleMember)
-  Functions/*.ps1      # function files
-docs/
-  <module>/            # each module has its own folder
-    index.md           # module overview
-    *.md               # subpages (aliases, helpers, completers, etc.)
-src/
-  align_tables.py      # markdown table alignment script
-  hooks/               # pre-commit hook scripts
-pyproject.toml         # Python deps (mkdocs, etc.) managed by uv
-```
+## Common commands
 
-## Adding a New Alias Function
-
-Three files must be updated in sync:
-
-1. **`Functions/<file>.ps1`** - add the function
-2. **`<module>.psm1`** - add to export list + dot-source if new file
-3. **`<module>.psd1`** - add to `FunctionsToExport`
-
-### Alias Function Pattern
-
-All alias functions use `Invoke-WriteExecCommand` (defined in `Functions/internal.ps1`).
-It prints the command in magenta then executes it via `Invoke-Expression`.
-
-```powershell
-function gexample {
-    [CmdletBinding(DefaultParameterSetName = 'Default')]
-    param (
-        [Parameter(ValueFromRemainingArguments)]
-        [string[]]$Xargs,
-
-        [Parameter(ParameterSetName = 'whatif')]
-        [switch]$WhatIf,
-
-        [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
-    )
-
-    Invoke-WriteExecCommand -Command 'git example' @PSBoundParameters
-}
-```
-
-Omit `$Xargs` param only when the command takes no extra arguments (e.g. `git restore --staged .`).
-
-## Markdown Rules
-
-### Gremlins
-
-Pre-commit rejects Unicode characters like em dashes (U+2014), smart quotes, etc. Use plain ASCII only.
-
-### Table Alignment (MD060)
-
-The linter enforces **aligned** table style - every row's pipe characters must be at the exact same column
-as the header. The `align-tables` pre-commit hook auto-fixes tables on commit. To run manually:
+**IMPORTANT**: Always run `make lint` after every code or docs change and fix all failures
+before reporting done. Do not run the underlying tools individually.
 
 ```bash
-python3 -m src.hooks.align_tables docs/**/*.md
+make                  # list available targets
+make lint             # run pre-commit hooks on changed files (run after every change)
+make lint-diff        # run hooks on files changed since main (use after /prepare-pr Phase 2)
+make lint-all         # run hooks on the entire repo
+make lint HOOK=<id>   # run a single hook by ID (e.g. make lint HOOK=gremlins-check)
+make mkdocs-build     # build the site with --strict; zero warnings required for docs changes
+make mkdocs-serve     # preview the site locally with live reload
 ```
 
-### Spelling
+## Golden rules
 
-Custom words go in `project-words.txt` (lowercase, sorted). The `validate-docs-words` pre-commit
-hook removes unused words automatically. Do NOT create alternative markdownlint config files -
-modify `.markdownlint.yml` only.
-
-### Markdownlint Config
-
-`.markdownlint.yml` settings:
-
-- MD013: line length 120, code blocks and tables exempt
-- MD024: siblings_only
-- MD046: disabled
-
-## mkdocs
-
-- Config: `mkdocs.yml`, deps in `pyproject.toml` (managed by `uv`)
-- Deploy: `.github/workflows/gh-pages.yml` uses `uv run mkdocs gh-deploy --force`
-- Doc filenames use hyphens (`aliases-git/` not `aliases_git/`)
-- Each module gets its own folder under `docs/`; small modules use a single `index.md`,
-  larger modules split into multiple pages by function group
-
-### mkdocs Features
-
-Docs use Material for MkDocs with these extensions:
-
-- **Emojis** in titles: `:material-git:`, `:octicons-mark-github-16:`, etc.
-- **Admonitions**: `!!! note`, `!!! tip`, `!!! warning`, `!!! danger`, `!!! example`, `!!! info`
-- **Collapsible blocks**: `??? info "Title"` (content must be indented 4 spaces)
-- Tables inside admonitions/collapsible blocks need blank line after the opener and 4-space indentation
+- **Modules**: adding/renaming/removing a public function or alias must update all three of
+  `Functions/<file>.ps1`, `<module>.psm1` (export list + dot-source), and `<module>.psd1`
+  (`FunctionsToExport`/`AliasesToExport`). See ARCHITECTURE.md section 2.
+- **Package manager**: `uv` (not pip/poetry). Pre-commit runner: `prek`.
+- **Markdown**: ASCII only (the `gremlins-check` hook rejects em dashes, smart quotes, NBSP).
+  Tables are auto-aligned by the `align-tables` hook. Config lives in `.markdownlint.yml` -
+  do not add alternative config files.
+- **Commits**: Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, `test:`,
+  `refactor:`); scope docs commits (`docs(do-common)`). Never `git add .` / `git add -A`
+  during consolidation; force-push only with `--force-with-lease`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,166 @@
+# Architecture
+
+How this repository is put together: the PowerShell modules, the docs site, and the
+Python tooling that lints and publishes them. Read this when you modify module
+structure, hooks, the build pipeline, or the docs layout. For day-to-day rules see
+[`AGENTS.md`](AGENTS.md); for mistakes made before, see [`design/lessons.md`](design/lessons.md).
+
+## 1. Repository layout
+
+```text
+modules/<name>/                PowerShell modules (one subfolder per module)
+  <name>.psd1                  manifest (FunctionsToExport, AliasesToExport, RequiredModules)
+  <name>.psm1                  root module: dot-sources Functions/*.ps1, then Export-ModuleMember
+  Functions/*.ps1              function definitions, grouped by concern
+docs/                          MkDocs site source (one subfolder per module + index.md)
+  <module>/                    index.md overview, plus subpages for larger modules
+src/hooks/                     custom pre-commit hook scripts (Python)
+design/lessons.md              operational lessons compounded by /prepare-pr
+.claude/skills/                agent skills (Claude Code slash commands)
+module_manage.ps1              install / remove / scaffold modules
+Makefile                       primary entry point (make = help)
+pyproject.toml + uv.lock       Python deps (mkdocs, ruff, prek) managed by uv
+mkdocs.yml                     MkDocs Material config
+.pre-commit-config.yaml        hook definitions (run via prek)
+```
+
+## 2. Module system
+
+Each module under `modules/<name>/` has three moving parts that must stay in sync:
+
+- **`<name>.psd1`** - the manifest. `FunctionsToExport` and `AliasesToExport` list the
+  public surface; `RequiredModules` / `#Requires` declare dependencies.
+- **`<name>.psm1`** - the root module. It dot-sources every `Functions/*.ps1` file at the
+  top, then calls `Export-ModuleMember` with an explicit `Function` + `Alias` list (never a
+  `*` wildcard - the explicit list keeps the public surface auditable and matched to the
+  manifest).
+- **`Functions/*.ps1`** - the actual function definitions, grouped by concern (e.g.
+  `certs.ps1`, `net.ps1`, `python.ps1`).
+
+### Module inventory
+
+| Module            | Function files | Purpose                                                            |
+| ----------------- | -------------- | ------------------------------------------------------------------ |
+| `aliases-git`     | 6              | 200+ `git`/`gh` alias functions built on `Invoke-WriteExecCommand` |
+| `aliases-kubectl` | 6              | 790+ composable `kubectl` aliases from a strict naming pattern     |
+| `do-az`           | 4              | Azure: subscriptions, Key Vault, AKS, Resource Graph, MS Graph     |
+| `do-common`       | 7              | Cross-platform, dependency-free: encoding, certs, venvs, net       |
+| `do-linux`        | 2              | Linux/WSL system info and sudo wrappers                            |
+| `do-win`          | 3              | Windows utilities (Linux-like commands, PATH, winget)              |
+| `psm-windows`     | 1              | Windows PowerShell (5.1) helpers                                   |
+
+### The three-file sync invariant
+
+Adding, renaming, or removing a public function or alias must touch all three places or the
+module ships broken:
+
+1. the function body in `Functions/<file>.ps1`,
+2. the export list in `<name>.psm1` (plus a `. $PSScriptRoot/Functions/<file>.ps1`
+   dot-source line if the file is new),
+3. `FunctionsToExport` / `AliasesToExport` in `<name>.psd1`.
+
+A symptom of a broken invariant: an export listed in the manifest/psm1 but not defined (or
+vice versa), a new `Functions/*.ps1` never dot-sourced, or a `Set-Alias` whose alias is
+missing from the export lists. Each module's public surface is also documented under
+`docs/<module>/`; changing exports usually needs a matching docs edit.
+
+### Alias-function pattern
+
+The alias modules (`aliases-git`, `aliases-kubectl`) build every alias on
+`Invoke-WriteExecCommand` (defined in `Functions/internal.ps1`), which prints the command in
+magenta then executes it via `Invoke-Expression`. All aliases support `-WhatIf` (preview)
+and `-Quiet` (silent) parameter sets.
+
+```powershell
+function gexample {
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
+    param (
+        [Parameter(ValueFromRemainingArguments)]
+        [string[]]$Xargs,
+
+        [Parameter(ParameterSetName = 'whatif')]
+        [switch]$WhatIf,
+
+        [Parameter(ParameterSetName = 'quiet')]
+        [switch]$Quiet
+    )
+
+    Invoke-WriteExecCommand -Command 'git example' @PSBoundParameters
+}
+```
+
+Omit the `$Xargs` param only when the command takes no extra arguments (e.g.
+`git restore --staged .`).
+
+### Managing modules
+
+`module_manage.ps1` installs, removes, and scaffolds modules; the Makefile wraps common
+invocations (`make install-common-do`, `make install-git-aliases`, etc.). Elevated sessions
+install to the AllUsers scope automatically. Requires PowerShell 7+.
+
+## 3. Pre-commit hooks
+
+`make lint` runs the hooks via `prek` (a `pre-commit` wrapper), configured in
+`.pre-commit-config.yaml`. Do not run the underlying tools individually.
+
+### Custom hooks (3 Python scripts in `src/hooks/`)
+
+| Hook                  | What it does                                                                    |
+| --------------------- | ------------------------------------------------------------------------------- |
+| `gremlins-check`      | Fails on unwanted Unicode (em dashes, smart quotes, NBSP, zero-width, etc.)     |
+| `align-tables`        | Auto-aligns markdown table columns so every row's pipes share a column (MD060)  |
+| `validate-docs-words` | Prunes unused words from `project-words.txt`, writes back sorted + deduplicated |
+
+### Vendored hooks
+
+`mkdocs-build` (`mkdocs build --strict`), `ruff-check`, `ruff-format` (both scoped to
+`src/`+`tests/`), `check-executables-have-shebangs`, `check-shebang-scripts-are-executable`,
+`end-of-file-fixer`, `mixed-line-ending`, `trailing-whitespace`, `markdownlint-cli2` (all
+`.md`), and `cspell` (docs + commit messages).
+
+## 4. Build and docs pipeline
+
+- **Docs**: MkDocs with the Material theme. Config in `mkdocs.yml`, deps in `pyproject.toml`.
+- **Preview**: `make mkdocs-serve` (live reload). **Build**: `make mkdocs-build`
+  (`--strict`; strict-mode warnings fail the build).
+- **Deploy**: `.github/workflows/gh-pages.yml` runs `mkdocs gh-deploy`; `make mkdocs-pages`
+  does it locally.
+- **CI**: `.github/workflows/repo_checks.yml` runs the prek hooks against the PR diff on
+  every pull request.
+- Doc filenames use hyphens (`aliases-git/`, not `aliases_git/`). Each module gets its own
+  folder under `docs/`; small modules use a single `index.md`, larger ones split into pages
+  by function group.
+
+### MkDocs / Markdown conventions
+
+- **Emojis** in titles: `:material-git:`, `:octicons-mark-github-16:`, etc.
+- **Admonitions**: `!!! note`, `!!! tip`, `!!! warning`, `!!! danger`, `!!! example`, `!!! info`.
+- **Collapsible blocks**: `??? info "Title"` (content indented 4 spaces).
+- Tables inside admonitions/collapsible blocks need a blank line after the opener and
+  4-space indentation.
+- **`.markdownlint.yml`**: MD013 line length 120 (code blocks + tables exempt), MD024
+  siblings_only, MD046 disabled. Do not create alternative markdownlint config files - edit
+  `.markdownlint.yml` only.
+- Custom spelling words go in `project-words.txt` (lowercase, sorted); the
+  `validate-docs-words` hook removes unused entries automatically.
+
+## 5. Tooling and workflow
+
+- **Package manager**: `uv` (not pip/poetry) - deps in `pyproject.toml`, lockfile `uv.lock`.
+- **Python version**: `~=3.14.0`.
+- **Pre-commit runner**: `prek`, invoked via `uv run --frozen prek`. All `lint*` targets
+  accept `HOOK=<id>` to run a single hook (e.g. `make lint HOOK=gremlins-check`).
+- **Conventional Commits** for messages (`feat:`, `fix:`, `docs:`, `chore:`, `test:`,
+  `refactor:`). Scope module docs commits: `docs(do-common)`, `chore(hooks)`.
+- During branch consolidation: never `git add .` / `git add -A` (use explicit file lists),
+  and force-push only with `--force-with-lease`.
+
+## 6. Agent skills
+
+Skills live in `.claude/skills/` as Claude Code slash commands.
+
+| Skill               | Purpose                                                               |
+| ------------------- | --------------------------------------------------------------------- |
+| `second-opinion`    | Heterogeneous-model review via GitHub Copilot CLI (GPT)               |
+| `address-pr-review` | Drive server-side Copilot PR review to a clean state                  |
+| `prepare-pr`        | Consolidate WIP commits by prefix, lint, push, and create/update a PR |

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,19 @@ SHELL := /bin/bash
 # Default target
 .DEFAULT_GOAL := help
 
+# MITM proxy support: use native TLS (OpenSSL) in prek to trust system CA certificates
+export PREK_NATIVE_TLS := 1
+# silence the deprecated `mkdocs.utils.warning_filter` access from mkdocs-roamlinks-plugin (unmaintained since 2023; fix is upstream-only)
+export PYTHONWARNINGS := ignore::DeprecationWarning:mkdocs.utils
+# Stage all changes, run prek, then restore the original index.
+# Auto-fixes from hooks land in the working tree; snapshotting the index file
+# (not just a path list) preserves the exact prior staging, partial hunks included.
+define PREK_RUN
+idx=$$(git rev-parse --git-path index); bak=$$(mktemp); cp -p "$$idx" "$$bak"; \
+git add --all && uv run --frozen --extra devel prek run $(HOOK) $(1); rc=$$?; \
+mv "$$bak" "$$idx"; exit $$rc
+endef
+
 .PHONY: help
 help: ## Show this help message
 	@printf 'Usage: make [target]\n\n'
@@ -20,19 +33,19 @@ upgrade: ## Upgrade all dependencies and pre-commit hooks
 	uv run prek autoupdate
 
 .PHONY: lint lint-diff lint-all
-lint: ## Lint and format code for changed files
+lint: ## Run pre-commit hooks for changed files (HOOK=id to run one hook)
 	@printf "🧭 Running pre-commit hooks for changed files...\n\n"
-	git add --all && uv run --frozen --extra devel prek run
-lint-diff: ## Run pre-commit hooks for files changed in this diff
+	@$(call PREK_RUN)
+lint-diff: ## Run pre-commit hooks for files changed in this diff (HOOK=id to run one hook)
 	@printf "🧭 Running pre-commit hooks for files changed in this diff...\n\n"
 	@if [ "$$(git branch --show-current)" = "main" ]; then \
 		printf "⚠️  You are on the main branch. Skipping lint-diff.\n"; \
 	else \
-		uv run --frozen --extra devel prek run --from-ref main --to-ref HEAD; \
+		$(call PREK_RUN,--from-ref main --to-ref HEAD); \
 	fi
-lint-all: ## Lint and format all files using pre-commit hooks
-	@printf "🧭 Running pre-commit hooks...\n"
-	uv run --frozen --extra devel prek run --all-files
+lint-all: ## Run pre-commit hooks for all files (HOOK=id to run one hook)
+	@printf "🧭 Running pre-commit hooks for all files...\n\n"
+	@$(call PREK_RUN,--all-files)
 
 .PHONY: install-git-aliases install-git-aliases-force
 install-git-aliases: ## install aliases-git module

--- a/design/lessons.md
+++ b/design/lessons.md
@@ -1,0 +1,18 @@
+# Operational Lessons
+
+Generalized rules extracted from PR history by `/prepare-pr`. Each entry captures a pattern the agent learned the
+hard way and the rule that prevents recurrence. Reviewed in the PR diff before merge.
+
+---
+
+## L-001 - 2026-07-09 - uri-parsing
+
+**Source:** PR #268, branch `fix/certificate-port-error-handling`
+
+When hand-rolling a URI/authority parser instead of using `[System.Uri]`, split the authority on the full set of
+delimiters `[/?#]`, not just `/`. A query string or fragment that follows the host with no intervening slash (e.g.
+`https://host:8443?q=1`) otherwise stays glued to the port and corrupts host/port extraction. Prefer `[System.Uri]`
+for absolute URIs and reserve manual parsing for bare `host` / `host:port` inputs; if manual parsing is kept, make
+the code strip every component the docstring claims it strips.
+
+---

--- a/docs/do-common/certs.md
+++ b/docs/do-common/certs.md
@@ -14,8 +14,18 @@ objects, and managing root certificates.
 | `Show-Certificate`          |          | Show cert chain for URI   |
 | `Show-CertificateChain`     |          | Show full cert chain      |
 | `Show-ConvertedPem`         | `pemdec` | Decode and display PEM    |
+| `Split-UriHostPort`         |          | Parse host and port       |
 
 !!! example "Inspect a certificate chain"
     ```powershell
     Show-Certificate -Uri 'https://github.com'
+    ```
+
+!!! example "Inspect a certificate on a non-default port"
+    ```powershell
+    # port appended to the host, like `openssl s_client -connect host:port`
+    Show-Certificate -Uri 'example.com:8443' -BuildChain
+
+    # or passed explicitly with -Port
+    Show-Certificate -Uri 'example.com' -Port 8443 -BuildChain
     ```

--- a/modules/do-common/Functions/certs.ps1
+++ b/modules/do-common/Functions/certs.ps1
@@ -176,10 +176,107 @@ function ConvertTo-PEM {
 
 <#
 .SYNOPSIS
+Split a Uri into its hostname and port components.
+
+.DESCRIPTION
+Accepts a bare hostname ('example.com'), a host:port pair ('example.com:8443')
+or a full Uri ('https://example.com:8443/path') and returns the hostname and
+port. A port embedded in the Uri takes precedence over the Port parameter.
+
+.PARAMETER Uri
+Uri, hostname or host:port string to parse.
+.PARAMETER Port
+Fallback port used when no port is embedded in the Uri.
+#>
+function Split-UriHostPort {
+    [CmdletBinding()]
+    [OutputType([System.Object[]])]
+    param (
+        [Parameter(Mandatory, Position = 0)]
+        [string]$Uri,
+
+        [Parameter(Position = 1)]
+        [ValidateRange(1, 65535)]
+        [int]$Port = 443
+    )
+
+    # strip scheme, then path/query/fragment, then userinfo to leave the authority component
+    $authority = (($Uri -replace '^[a-zA-Z][\w+.-]*://') -split '[/?#]', 2)[0].Split('@')[-1]
+
+    if ($authority -match '^\[(?<host>.+)\](?::(?<port>\d+))?$') {
+        # bracketed IPv6 literal, optionally with a port
+        $hostname = $Matches.host
+        if ($Matches.port) { $Port = [int]$Matches.port }
+    } elseif ($authority -match '^(?<host>[^:]+):(?<port>\d+)$') {
+        # host:port
+        $hostname = $Matches.host
+        $Port = [int]$Matches.port
+    } elseif ($authority -match '^[^:]+:[^:]*$') {
+        # single colon but a non-numeric/empty port - fail fast instead of mis-parsing as a hostname
+        throw "Invalid port in Uri '$Uri'. Expected 'host:<number>'."
+    } else {
+        # bare hostname or bare (unbracketed) IPv6 literal
+        $hostname = $authority
+    }
+
+    return $hostname, $Port
+}
+
+
+<#
+.SYNOPSIS
+Build a concise ErrorRecord for certificate retrieval failures.
+
+.DESCRIPTION
+Unwraps nested .NET exceptions (e.g. the SocketException behind a
+"Exception calling ..." wrapper) so the reported message states the actual
+cause and prefixes it with the target host:port.
+
+.PARAMETER Exception
+Exception thrown while connecting or performing the TLS handshake.
+.PARAMETER Target
+Target 'host:port' the certificate was requested from.
+#>
+function New-CertificateError {
+    [CmdletBinding()]
+    [OutputType([System.Management.Automation.ErrorRecord])]
+    param (
+        [Parameter(Mandatory, Position = 0)]
+        [System.Exception]$Exception,
+
+        [Parameter(Mandatory, Position = 1)]
+        [string]$Target
+    )
+
+    # drill down to the innermost exception for the root-cause message
+    $inner = $Exception
+    while ($inner.InnerException) {
+        $inner = $inner.InnerException
+    }
+    # pick the error category based on the underlying exception type
+    $category = $inner -is [System.Net.Sockets.SocketException] `
+        ? [System.Management.Automation.ErrorCategory]::ConnectionError
+        : [System.Management.Automation.ErrorCategory]::NotSpecified
+
+    return [System.Management.Automation.ErrorRecord]::new(
+        [System.Exception]::new("Failed to get certificate from '$Target'. $($inner.Message)", $Exception),
+        'CertificateRetrievalError',
+        $category,
+        $Target
+    )
+}
+
+
+<#
+.SYNOPSIS
 Get certificate(s) from specified Uri.
 
 .PARAMETER Uri
-Uri used for intercepting certificate.
+Uri used for intercepting certificate. The port can be appended to the host
+(e.g. 'example.com:8443'), analogous to `openssl s_client -connect host:port`.
+.PARAMETER Port
+Port used for the TLS connection. Defaults to 443 and is overridden by a port
+embedded in the Uri.
 .PARAMETER BuildChain
 Switch whether to build full certificate chain.
 .PARAMETER IgnoreValidation
@@ -192,35 +289,51 @@ function Get-Certificate {
         [Parameter(Mandatory, Position = 0)]
         [string]$Uri,
 
+        [Parameter(Position = 1)]
+        [ValidateRange(1, 65535)]
+        [int]$Port = 443,
+
         [switch]$BuildChain,
 
         [switch]$IgnoreValidation
     )
 
     begin {
-        $tcpClient = [System.Net.Sockets.TcpClient]::new($Uri, 443)
-        if ($BuildChain) {
-            $chain = [System.Security.Cryptography.X509Certificates.X509Chain]::new()
-        }
-        if ($IgnoreValidation) {
-            $sslStream = [System.Net.Security.SslStream]::new($tcpClient.GetStream(), $false, { $true })
-            if ($BuildChain) {
-                $chain.ChainPolicy.VerificationFlags = [System.Security.Cryptography.X509Certificates.X509VerificationFlags]::AllFlags
-            }
-        } else {
-            $sslStream = [System.Net.Security.SslStream]::new($tcpClient.GetStream())
+        # parse hostname and port from the Uri ('host', 'host:port' or 'scheme://host:port/path')
+        try {
+            $hostname, $Port = Split-UriHostPort -Uri $Uri -Port $Port
+        } catch {
+            $PSCmdlet.ThrowTerminatingError((New-CertificateError -Exception $_.Exception -Target $Uri))
         }
     }
 
     process {
+        $tcpClient = $sslStream = $null
         try {
-            $sslStream.AuthenticateAsClient($Uri)
+            # open the TCP connection to the target host and port
+            $tcpClient = [System.Net.Sockets.TcpClient]::new($hostname, $Port)
+
+            # perform the TLS handshake to intercept the presented certificate
+            if ($IgnoreValidation) {
+                $sslStream = [System.Net.Security.SslStream]::new($tcpClient.GetStream(), $false, { $true })
+            } else {
+                $sslStream = [System.Net.Security.SslStream]::new($tcpClient.GetStream())
+            }
+            $sslStream.AuthenticateAsClient($hostname)
             $certificate = $sslStream.RemoteCertificate
+        } catch {
+            # surface a concise, categorized error instead of the raw .NET exception
+            $PSCmdlet.ThrowTerminatingError((New-CertificateError -Exception $_.Exception -Target "${hostname}:${Port}"))
         } finally {
-            $sslStream.Close()
+            if ($sslStream) { $sslStream.Dispose() }
+            if ($tcpClient) { $tcpClient.Dispose() }
         }
 
         if ($BuildChain) {
+            $chain = [System.Security.Cryptography.X509Certificates.X509Chain]::new()
+            if ($IgnoreValidation) {
+                $chain.ChainPolicy.VerificationFlags = [System.Security.Cryptography.X509Certificates.X509VerificationFlags]::AllFlags
+            }
             $isChainValid = $chain.Build($certificate)
             if ($isChainValid) {
                 $certificate = $chain.ChainElements.Certificate
@@ -241,7 +354,11 @@ function Get-Certificate {
 Get certificate(s) from specified Uri using OpenSSL application.
 
 .PARAMETER Uri
-Uri used for intercepting certificate.
+Uri used for intercepting certificate. The port can be appended to the host
+(e.g. 'example.com:8443'), analogous to `openssl s_client -connect host:port`.
+.PARAMETER Port
+Port used for the TLS connection. Defaults to 443 and is overridden by a port
+embedded in the Uri.
 .PARAMETER BuildChain
 Switch whether to build full certificate chain.
 #>
@@ -252,19 +369,41 @@ function Get-CertificateOpenSSL {
         [Parameter(Mandatory, Position = 0)]
         [string]$Uri,
 
+        [Parameter(Position = 1)]
+        [ValidateRange(1, 65535)]
+        [int]$Port = 443,
+
         [switch]$BuildChain
     )
 
     begin {
         # check if OpenSSL is installed
         if (-not (Get-Command openssl -CommandType Application -ErrorAction SilentlyContinue)) {
-            Throw 'OpenSSL not found. Script execution halted.'
+            $er = [System.Management.Automation.ErrorRecord]::new(
+                [System.Exception]::new('OpenSSL not found. Install OpenSSL or omit the -OpenSSL switch.'),
+                'OpenSSLNotFound',
+                [System.Management.Automation.ErrorCategory]::NotInstalled,
+                'openssl'
+            )
+            $PSCmdlet.ThrowTerminatingError($er)
         }
+
+        # parse hostname and port from the Uri ('host', 'host:port' or 'scheme://host:port/path')
+        try {
+            $hostname, $Port = Split-UriHostPort -Uri $Uri -Port $Port
+        } catch {
+            $PSCmdlet.ThrowTerminatingError((New-CertificateError -Exception $_.Exception -Target $Uri))
+        }
+
+        # bracket IPv6 literals (a bare colon in the host) for OpenSSL's host:port syntax
+        $connectHost = $hostname.Contains(':') ? "[$hostname]" : $hostname
 
         # build the OpenSSL argument list
         [System.Collections.Generic.List[string]]$cmdArgs = @('s_client')
         $cmdArgs.Add('-connect')
-        $cmdArgs.Add("${Uri}:443")
+        $cmdArgs.Add("${connectHost}:${Port}")
+        $cmdArgs.Add('-servername')
+        $cmdArgs.Add($hostname)
         if ($BuildChain) {
             $cmdArgs.Add('-showcerts')
         }
@@ -275,11 +414,17 @@ function Get-CertificateOpenSSL {
             # Use the call operator (&) to execute OpenSSL with arguments
             $opensslOutput = Out-Null | & openssl @cmdArgs 2>$null
         } catch {
-            Throw "Error executing OpenSSL: $_"
+            $PSCmdlet.ThrowTerminatingError((New-CertificateError -Exception $_.Exception -Target "${hostname}:${Port}"))
         }
 
         if (-not $opensslOutput) {
-            Throw "No output from OpenSSL. Possibly an unknown host: `"$Uri`"."
+            $er = [System.Management.Automation.ErrorRecord]::new(
+                [System.Exception]::new("Failed to get certificate from '${hostname}:${Port}'. No output from OpenSSL, possibly an unknown host."),
+                'CertificateRetrievalError',
+                [System.Management.Automation.ErrorCategory]::ConnectionError,
+                "${hostname}:${Port}"
+            )
+            $PSCmdlet.ThrowTerminatingError($er)
         }
 
         # Normalize the output: join array into one string and standardize line breaks
@@ -290,7 +435,13 @@ function Get-CertificateOpenSSL {
         $reMatches = [regex]::Matches($outputText, $pemPattern)
 
         if ($reMatches.Count -eq 0) {
-            Throw "No certificates found in OpenSSL output for `"$Uri`"."
+            $er = [System.Management.Automation.ErrorRecord]::new(
+                [System.Exception]::new("Failed to get certificate from '${hostname}:${Port}'. No certificates found in OpenSSL output."),
+                'CertificateRetrievalError',
+                [System.Management.Automation.ErrorCategory]::InvalidResult,
+                "${hostname}:${Port}"
+            )
+            $PSCmdlet.ThrowTerminatingError($er)
         }
 
         # Convert each PEM block to an X509Certificate2 object
@@ -326,7 +477,11 @@ function Get-RootCertificates {
 Show certificate chain for a specified Uri.
 
 .PARAMETER Uri
-Uri used for intercepting certificate chain.
+Uri used for intercepting certificate chain. The port can be appended to the
+host (e.g. 'example.com:8443'), analogous to `openssl s_client -connect host:port`.
+.PARAMETER Port
+Port used for the TLS connection. Defaults to 443 and is overridden by a port
+embedded in the Uri.
 .PARAMETER InputObject
 Object from pipeline to show certificate properties.
 .PARAMETER BuildChain
@@ -346,6 +501,10 @@ function Show-Certificate {
     param (
         [Parameter(Mandatory, Position = 0, ParameterSetName = 'FromUri')]
         [string]$Uri,
+
+        [Parameter(Position = 1, ParameterSetName = 'FromUri')]
+        [ValidateRange(1, 65535)]
+        [int]$Port = 443,
 
         [Parameter(Mandatory, ValueFromPipeline, ParameterSetName = 'FromPipeline')]
         [System.Security.Cryptography.X509Certificates.X509Certificate2[]]$InputObject,
@@ -394,11 +553,16 @@ function Show-Certificate {
     process {
         switch ($PsCmdlet.ParameterSetName) {
             FromUri {
-                $cert = if ($PSBoundParameters.OpenSSL) {
-                    $PSBoundParameters.Remove('OpenSSL') | Out-Null
-                    Get-CertificateOpenSSL @PSBoundParameters | Add-CertificateProperties
-                } else {
-                    Get-Certificate @PSBoundParameters | Add-CertificateProperties
+                try {
+                    $cert = if ($PSBoundParameters.OpenSSL) {
+                        $PSBoundParameters.Remove('OpenSSL') | Out-Null
+                        Get-CertificateOpenSSL @PSBoundParameters | Add-CertificateProperties
+                    } else {
+                        Get-Certificate @PSBoundParameters | Add-CertificateProperties
+                    }
+                } catch {
+                    # re-throw the concise error from Get-Certificate without the wrapper's call-site noise
+                    $PSCmdlet.ThrowTerminatingError($_)
                 }
             }
             FromPipeline {
@@ -419,7 +583,11 @@ function Show-Certificate {
 Show certificate chain for a specified Uri.
 
 .PARAMETER Uri
-Uri used for intercepting certificate chain.
+Uri used for intercepting certificate chain. The port can be appended to the
+host (e.g. 'example.com:8443'), analogous to `openssl s_client -connect host:port`.
+.PARAMETER Port
+Port used for the TLS connection. Defaults to 443 and is overridden by a port
+embedded in the Uri.
 .PARAMETER Extended
 Switch, whether to show extended certificate properties.
 .PARAMETER Strip
@@ -435,6 +603,10 @@ function Show-CertificateChain {
     param (
         [Parameter(Mandatory, Position = 0)]
         [string]$Uri,
+
+        [Parameter(Position = 1)]
+        [ValidateRange(1, 65535)]
+        [int]$Port = 443,
 
         [Parameter(Mandatory, ParameterSetName = 'Extended')]
         [switch]$Extended,
@@ -453,7 +625,12 @@ function Show-CertificateChain {
     }
 
     process {
-        Show-Certificate @PSBoundParameters
+        try {
+            Show-Certificate @PSBoundParameters
+        } catch {
+            # re-throw the concise error without the wrapper's call-site noise
+            $PSCmdlet.ThrowTerminatingError($_)
+        }
     }
 }
 

--- a/modules/do-common/do-common.psd1
+++ b/modules/do-common/do-common.psd1
@@ -42,6 +42,7 @@
         'Show-Certificate'
         'Show-CertificateChain'
         'Show-ConvertedPem'
+        'Split-UriHostPort'
         # cli
         'Invoke-DigColored'
         # common

--- a/modules/do-common/do-common.psm1
+++ b/modules/do-common/do-common.psm1
@@ -20,6 +20,7 @@ $exportModuleMemberParams = @{
         'Show-Certificate'
         'Show-CertificateChain'
         'Show-ConvertedPem'
+        'Split-UriHostPort'
         # cli
         'Invoke-DigColored'
         # common

--- a/uv.lock
+++ b/uv.lock
@@ -13,78 +13,71 @@ wheels = [
 
 [[package]]
 name = "backrefs"
-version = "6.2"
+version = "7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/a6/e325ec73b638d3ede4421b5445d4a0b8b219481826cc079d510100af356c/backrefs-6.2.tar.gz", hash = "sha256:f44ff4d48808b243b6c0cdc6231e22195c32f77046018141556c66f8bab72a49", size = 7012303, upload-time = "2026-02-16T19:10:15.828Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/a7dd63622beef68cc0d3c3c36d472e143dd95443d5ebf14cd1a5b4dfbf11/backrefs-7.0.tar.gz", hash = "sha256:4989bb9e1e99eb23647c7160ed51fb21d0b41b5d200f2d3017da41e023097e82", size = 7012453, upload-time = "2026-04-28T16:28:04.215Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/39/3765df263e08a4df37f4f43cb5aa3c6c17a4bdd42ecfe841e04c26037171/backrefs-6.2-py310-none-any.whl", hash = "sha256:0fdc7b012420b6b144410342caeb8adc54c6866cf12064abc9bb211302e496f8", size = 381075, upload-time = "2026-02-16T19:10:04.322Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/f0/35240571e1b67ffb19dafb29ab34150b6f59f93f717b041082cdb1bfceb1/backrefs-6.2-py311-none-any.whl", hash = "sha256:08aa7fae530c6b2361d7bdcbda1a7c454e330cc9dbcd03f5c23205e430e5c3be", size = 392874, upload-time = "2026-02-16T19:10:06.314Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/63/77e8c9745b4d227cce9f5e0a6f68041278c5f9b18588b35905f5f19c1beb/backrefs-6.2-py312-none-any.whl", hash = "sha256:c3f4b9cb2af8cda0d87ab4f57800b57b95428488477be164dd2b47be54db0c90", size = 398787, upload-time = "2026-02-16T19:10:08.274Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/71/c754b1737ad99102e03fa3235acb6cb6d3ac9d6f596cbc3e5f236705abd8/backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b", size = 400747, upload-time = "2026-02-16T19:10:09.791Z" },
-    { url = "https://files.pythonhosted.org/packages/af/75/be12ba31a6eb20dccef2320cd8ccb3f7d9013b68ba4c70156259fee9e409/backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7", size = 412602, upload-time = "2026-02-16T19:10:12.317Z" },
-    { url = "https://files.pythonhosted.org/packages/21/f8/d02f650c47d05034dcd6f9c8cf94f39598b7a89c00ecda0ecb2911bc27e9/backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7", size = 381077, upload-time = "2026-02-16T19:10:13.74Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/39/39a31d7eae729ea14ed10c3ccef79371197177b9355a86cb3525709e8502/backrefs-7.0-py310-none-any.whl", hash = "sha256:b57cd227ea556b0aed3dc9b8da4628db4eabc0402c6d7fcfc69283a93955f7e9", size = 380824, upload-time = "2026-04-28T16:27:55.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b5/9302644225ba7dfa934a2ff2b9c7bb85701313a90dddb3dfaf693fa5bae2/backrefs-7.0-py311-none-any.whl", hash = "sha256:a0fa7360c63509e9e077e174ef4e6d3c21c8db94189b9d957289ae6d794b9475", size = 392626, upload-time = "2026-04-28T16:27:57.42Z" },
+    { url = "https://files.pythonhosted.org/packages/36/da/87912ddec6e06feffbaa3d7aa18fc6352bee2e8f1fee185d7d1690f8f4e8/backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12", size = 398537, upload-time = "2026-04-28T16:27:58.913Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bb/90ba423612b6aa0adccc6b1874bcd4a9b44b660c0c16f346611e00f64ac3/backrefs-7.0-py313-none-any.whl", hash = "sha256:f2c52955d631b9e1ac4cd56209f0a3a946d592b98e7790e77699339ae01c102a", size = 400491, upload-time = "2026-04-28T16:28:00.928Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/5c/fb93d3092640a24dfb7bd7727a24016d7c01774ca013e60efd3f683c8002/backrefs-7.0-py314-none-any.whl", hash = "sha256:a6448b28180e3ca01134c9cf09dcebafad8531072e09903c5451748a05f24bc9", size = 412349, upload-time = "2026-04-28T16:28:02.412Z" },
 ]
 
 [[package]]
 name = "certifi"
-version = "2026.2.25"
+version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
 ]
 
 [[package]]
 name = "charset-normalizer"
-version = "3.4.6"
+version = "3.4.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/60/e3bec1881450851b087e301bedc3daa9377a4d45f1c26aa90b0b235e38aa/charset_normalizer-3.4.6.tar.gz", hash = "sha256:1ae6b62897110aa7c79ea2f5dd38d1abca6db663687c0b1ad9aed6f6bae3d9d6", size = 143363, upload-time = "2026-03-15T18:53:25.478Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/6f/ffe1e1259f384594063ea1869bfb6be5cdb8bc81020fc36c3636bc8302a1/charset_normalizer-3.4.6-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9cc6e6d9e571d2f863fa77700701dae73ed5f78881efc8b3f9a4398772ff53e8", size = 294458, upload-time = "2026-03-15T18:51:41.134Z" },
-    { url = "https://files.pythonhosted.org/packages/56/60/09bb6c13a8c1016c2ed5c6a6488e4ffef506461aa5161662bd7636936fb1/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5960d965e67165d75b7c7ffc60a83ec5abfc5c11b764ec13ea54fbef8b4421", size = 199277, upload-time = "2026-03-15T18:51:42.953Z" },
-    { url = "https://files.pythonhosted.org/packages/00/50/dcfbb72a5138bbefdc3332e8d81a23494bf67998b4b100703fd15fa52d81/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b3694e3f87f8ac7ce279d4355645b3c878d24d1424581b46282f24b92f5a4ae2", size = 218758, upload-time = "2026-03-15T18:51:44.339Z" },
-    { url = "https://files.pythonhosted.org/packages/03/b3/d79a9a191bb75f5aa81f3aaaa387ef29ce7cb7a9e5074ba8ea095cc073c2/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5d11595abf8dd942a77883a39d81433739b287b6aa71620f15164f8096221b30", size = 215299, upload-time = "2026-03-15T18:51:45.871Z" },
-    { url = "https://files.pythonhosted.org/packages/76/7e/bc8911719f7084f72fd545f647601ea3532363927f807d296a8c88a62c0d/charset_normalizer-3.4.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7bda6eebafd42133efdca535b04ccb338ab29467b3f7bf79569883676fc628db", size = 206811, upload-time = "2026-03-15T18:51:47.308Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/40/c430b969d41dda0c465aa36cc7c2c068afb67177bef50905ac371b28ccc7/charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:bbc8c8650c6e51041ad1be191742b8b421d05bbd3410f43fa2a00c8db87678e8", size = 193706, upload-time = "2026-03-15T18:51:48.849Z" },
-    { url = "https://files.pythonhosted.org/packages/48/15/e35e0590af254f7df984de1323640ef375df5761f615b6225ba8deb9799a/charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22c6f0c2fbc31e76c3b8a86fba1a56eda6166e238c29cdd3d14befdb4a4e4815", size = 202706, upload-time = "2026-03-15T18:51:50.257Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/bd/f736f7b9cc5e93a18b794a50346bb16fbfd6b37f99e8f306f7951d27c17c/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7edbed096e4a4798710ed6bc75dcaa2a21b68b6c356553ac4823c3658d53743a", size = 202497, upload-time = "2026-03-15T18:51:52.012Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/ba/2cc9e3e7dfdf7760a6ed8da7446d22536f3d0ce114ac63dee2a5a3599e62/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:7f9019c9cb613f084481bd6a100b12e1547cf2efe362d873c2e31e4035a6fa43", size = 193511, upload-time = "2026-03-15T18:51:53.723Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/cb/5be49b5f776e5613be07298c80e1b02a2d900f7a7de807230595c85a8b2e/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:58c948d0d086229efc484fe2f30c2d382c86720f55cd9bc33591774348ad44e0", size = 220133, upload-time = "2026-03-15T18:51:55.333Z" },
-    { url = "https://files.pythonhosted.org/packages/83/43/99f1b5dad345accb322c80c7821071554f791a95ee50c1c90041c157ae99/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:419a9d91bd238052642a51938af8ac05da5b3343becde08d5cdeab9046df9ee1", size = 203035, upload-time = "2026-03-15T18:51:56.736Z" },
-    { url = "https://files.pythonhosted.org/packages/87/9a/62c2cb6a531483b55dddff1a68b3d891a8b498f3ca555fbcf2978e804d9d/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:5273b9f0b5835ff0350c0828faea623c68bfa65b792720c453e22b25cc72930f", size = 216321, upload-time = "2026-03-15T18:51:58.17Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/79/94a010ff81e3aec7c293eb82c28f930918e517bc144c9906a060844462eb/charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:0e901eb1049fdb80f5bd11ed5ea1e498ec423102f7a9b9e4645d5b8204ff2815", size = 208973, upload-time = "2026-03-15T18:51:59.998Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/57/4ecff6d4ec8585342f0c71bc03efaa99cb7468f7c91a57b105bcd561cea8/charset_normalizer-3.4.6-cp314-cp314-win32.whl", hash = "sha256:b4ff1d35e8c5bd078be89349b6f3a845128e685e751b6ea1169cf2160b344c4d", size = 144610, upload-time = "2026-03-15T18:52:02.213Z" },
-    { url = "https://files.pythonhosted.org/packages/80/94/8434a02d9d7f168c25767c64671fead8d599744a05d6a6c877144c754246/charset_normalizer-3.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:74119174722c4349af9708993118581686f343adc1c8c9c007d59be90d077f3f", size = 154962, upload-time = "2026-03-15T18:52:03.658Z" },
-    { url = "https://files.pythonhosted.org/packages/46/4c/48f2cdbfd923026503dfd67ccea45c94fd8fe988d9056b468579c66ed62b/charset_normalizer-3.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:e5bcc1a1ae744e0bb59641171ae53743760130600da8db48cbb6e4918e186e4e", size = 143595, upload-time = "2026-03-15T18:52:05.123Z" },
-    { url = "https://files.pythonhosted.org/packages/31/93/8878be7569f87b14f1d52032946131bcb6ebbd8af3e20446bc04053dc3f1/charset_normalizer-3.4.6-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ad8faf8df23f0378c6d527d8b0b15ea4a2e23c89376877c598c4870d1b2c7866", size = 314828, upload-time = "2026-03-15T18:52:06.831Z" },
-    { url = "https://files.pythonhosted.org/packages/06/b6/fae511ca98aac69ecc35cde828b0a3d146325dd03d99655ad38fc2cc3293/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f5ea69428fa1b49573eef0cc44a1d43bebd45ad0c611eb7d7eac760c7ae771bc", size = 208138, upload-time = "2026-03-15T18:52:08.239Z" },
-    { url = "https://files.pythonhosted.org/packages/54/57/64caf6e1bf07274a1e0b7c160a55ee9e8c9ec32c46846ce59b9c333f7008/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:06a7e86163334edfc5d20fe104db92fcd666e5a5df0977cb5680a506fe26cc8e", size = 224679, upload-time = "2026-03-15T18:52:10.043Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/cb/9ff5a25b9273ef160861b41f6937f86fae18b0792fe0a8e75e06acb08f1d/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e1f6e2f00a6b8edb562826e4632e26d063ac10307e80f7461f7de3ad8ef3f077", size = 223475, upload-time = "2026-03-15T18:52:11.854Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/97/440635fc093b8d7347502a377031f9605a1039c958f3cd18dcacffb37743/charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95b52c68d64c1878818687a473a10547b3292e82b6f6fe483808fb1468e2f52f", size = 215230, upload-time = "2026-03-15T18:52:13.325Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/24/afff630feb571a13f07c8539fbb502d2ab494019492aaffc78ef41f1d1d0/charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:7504e9b7dc05f99a9bbb4525c67a2c155073b44d720470a148b34166a69c054e", size = 199045, upload-time = "2026-03-15T18:52:14.752Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/17/d1399ecdaf7e0498c327433e7eefdd862b41236a7e484355b8e0e5ebd64b/charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:172985e4ff804a7ad08eebec0a1640ece87ba5041d565fff23c8f99c1f389484", size = 211658, upload-time = "2026-03-15T18:52:16.278Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/38/16baa0affb957b3d880e5ac2144caf3f9d7de7bc4a91842e447fbb5e8b67/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4be9f4830ba8741527693848403e2c457c16e499100963ec711b1c6f2049b7c7", size = 210769, upload-time = "2026-03-15T18:52:17.782Z" },
-    { url = "https://files.pythonhosted.org/packages/05/34/c531bc6ac4c21da9ddfddb3107be2287188b3ea4b53b70fc58f2a77ac8d8/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:79090741d842f564b1b2827c0b82d846405b744d31e84f18d7a7b41c20e473ff", size = 201328, upload-time = "2026-03-15T18:52:19.553Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/73/a5a1e9ca5f234519c1953608a03fe109c306b97fdfb25f09182babad51a7/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:87725cfb1a4f1f8c2fc9890ae2f42094120f4b44db9360be5d99a4c6b0e03a9e", size = 225302, upload-time = "2026-03-15T18:52:21.043Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/f6/cd782923d112d296294dea4bcc7af5a7ae0f86ab79f8fefbda5526b6cfc0/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:fcce033e4021347d80ed9c66dcf1e7b1546319834b74445f561d2e2221de5659", size = 211127, upload-time = "2026-03-15T18:52:22.491Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/c5/0b6898950627af7d6103a449b22320372c24c6feda91aa24e201a478d161/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:ca0276464d148c72defa8bb4390cce01b4a0e425f3b50d1435aa6d7a18107602", size = 222840, upload-time = "2026-03-15T18:52:24.113Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/25/c4bba773bef442cbdc06111d40daa3de5050a676fa26e85090fc54dd12f0/charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:197c1a244a274bb016dd8b79204850144ef77fe81c5b797dc389327adb552407", size = 216890, upload-time = "2026-03-15T18:52:25.541Z" },
-    { url = "https://files.pythonhosted.org/packages/35/1a/05dacadb0978da72ee287b0143097db12f2e7e8d3ffc4647da07a383b0b7/charset_normalizer-3.4.6-cp314-cp314t-win32.whl", hash = "sha256:2a24157fa36980478dd1770b585c0f30d19e18f4fb0c47c13aa568f871718579", size = 155379, upload-time = "2026-03-15T18:52:27.05Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/7a/d269d834cb3a76291651256f3b9a5945e81d0a49ab9f4a498964e83c0416/charset_normalizer-3.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:cd5e2801c89992ed8c0a3f0293ae83c159a60d9a5d685005383ef4caca77f2c4", size = 169043, upload-time = "2026-03-15T18:52:28.502Z" },
-    { url = "https://files.pythonhosted.org/packages/23/06/28b29fba521a37a8932c6a84192175c34d49f84a6d4773fa63d05f9aff22/charset_normalizer-3.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:47955475ac79cc504ef2704b192364e51d0d473ad452caedd0002605f780101c", size = 148523, upload-time = "2026-03-15T18:52:29.956Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/68/687187c7e26cb24ccbd88e5069f5ef00eba804d36dde11d99aad0838ab45/charset_normalizer-3.4.6-py3-none-any.whl", hash = "sha256:947cf925bc916d90adba35a64c82aace04fa39b46b52d4630ece166655905a69", size = 61455, upload-time = "2026-03-15T18:53:23.833Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
 ]
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
 ]
 
 [[package]]
@@ -110,11 +103,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -255,7 +248,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.7.1"
+version = "9.7.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -270,9 +263,9 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/e2/2ffc356cd72f1473d07c7719d82a8f2cbd261666828614ecb95b12169f41/mkdocs_material-9.7.1.tar.gz", hash = "sha256:89601b8f2c3e6c6ee0a918cc3566cb201d40bf37c3cd3c2067e26fadb8cce2b8", size = 4094392, upload-time = "2025-12-18T09:49:00.308Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/32/ed071cb721aca8c227718cffcf7bd539620e9799bbf2619e90c757bfd030/mkdocs_material-9.7.1-py3-none-any.whl", hash = "sha256:3f6100937d7d731f87f1e3e3b021c97f7239666b9ba1151ab476cabb96c60d5c", size = 9297166, upload-time = "2025-12-18T09:48:56.664Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
 ]
 
 [[package]]
@@ -299,21 +292,23 @@ wheels = [
 
 [[package]]
 name = "mkdocs-redirects"
-version = "1.2.2"
+version = "1.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mkdocs" },
+    { name = "properdocs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/a8/6d44a6cf07e969c7420cb36ab287b0669da636a2044de38a7d2208d5a758/mkdocs_redirects-1.2.2.tar.gz", hash = "sha256:3094981b42ffab29313c2c1b8ac3969861109f58b2dd58c45fc81cd44bfa0095", size = 7162, upload-time = "2024-11-07T14:57:21.109Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/25/49725f78ca5d3026b09973f7a2b3a8b179cc2e8c15e43d5a13bc79f6b274/mkdocs_redirects-1.2.3.tar.gz", hash = "sha256:5e980330999299729a2d6a125347d1af78023d68a23681a4de3053ce7dfe2e51", size = 7712, upload-time = "2026-03-28T13:57:41.766Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/ec/38443b1f2a3821bbcb24e46cd8ba979154417794d54baf949fefde1c2146/mkdocs_redirects-1.2.2-py3-none-any.whl", hash = "sha256:7dbfa5647b79a3589da4401403d69494bd1f4ad03b9c15136720367e1f340ed5", size = 6142, upload-time = "2024-11-07T14:57:19.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/90/871b1cddc01d2ba1637b858eeeabc2e3013dc8df591306b5567b98ef0870/mkdocs_redirects-1.2.3-py3-none-any.whl", hash = "sha256:ec7312fff462d03ec16395d0c001006a418f8d0c21cdf2b47ff11cf839dc3ce0", size = 6245, upload-time = "2026-03-28T13:57:40.466Z" },
 ]
 
 [[package]]
 name = "mkdocs-techdocs-core"
-version = "1.6.1"
+version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "click" },
     { name = "markdown" },
     { name = "markdown-graphviz-inline" },
     { name = "mdx-truly-sane-lists" },
@@ -325,18 +320,18 @@ dependencies = [
     { name = "pygments" },
     { name = "pymdown-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/b2/af3694f88c45bb595bc49ebcf51987545a7e873759da6eebeb4055d00ea8/mkdocs_techdocs_core-1.6.1.tar.gz", hash = "sha256:a27fc10c3aa7d21832a4b0ab22096e7fd13f83809570e3729ec405f22679a4ea", size = 13503, upload-time = "2025-12-22T17:54:02.205Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/5a/63c03c78dbc69aaf8cae480bea9653902314b21967587a91a9cc5e1113cf/mkdocs_techdocs_core-1.6.2.tar.gz", hash = "sha256:d6d1517341d108fef20da6e9912ff29cea574915654ef29204c156232d58ccc0", size = 13578, upload-time = "2026-04-15T17:18:32.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/b5/833ac5e4b81fd78f044bb2d7d1199e7fed475cc7688efda76941ee930fae/mkdocs_techdocs_core-1.6.1-py3-none-any.whl", hash = "sha256:6e6b39d07b6e9680dc26f110ced579fcef87f700a32a6ad77ec36636a7c5f801", size = 14252, upload-time = "2025-12-22T17:54:01.347Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/43/eab9b0da8c16f411600bf2d841b87640651a2b308429a4d98c0afd7b2bfe/mkdocs_techdocs_core-1.6.2-py3-none-any.whl", hash = "sha256:d4f212fa19bb0e85af7689cc4950b0d0ef00e3528cf2d767a435b75615dd0596", size = 14266, upload-time = "2026-04-15T17:18:31.113Z" },
 ]
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]
@@ -350,11 +345,11 @@ wheels = [
 
 [[package]]
 name = "pathspec"
-version = "1.0.4"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -373,35 +368,58 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.9.4"
+version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]
 name = "prek"
-version = "0.3.8"
+version = "0.4.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/62/ee/03e8180e3fda9de25b6480bd15cc2bde40d573868d50648b0e527b35562f/prek-0.3.8.tar.gz", hash = "sha256:434a214256516f187a3ab15f869d950243be66b94ad47987ee4281b69643a2d9", size = 400224, upload-time = "2026-03-23T08:23:35.981Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/46/e436a6eb9fdb4d3fd08d0ab7fdba19fe03a9e994ec810de57869b853bd8e/prek-0.4.8.tar.gz", hash = "sha256:d15d8bef72ab7b02c7dc01458ac9e05b3131534492b5ce9bb11c4f6f636fa868", size = 494570, upload-time = "2026-07-04T12:05:10.941Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/84/40d2ddf362d12c4cd4a25a8c89a862edf87cdfbf1422aa41aac8e315d409/prek-0.3.8-py3-none-linux_armv6l.whl", hash = "sha256:6fb646ada60658fa6dd7771b2e0fb097f005151be222f869dada3eb26d79ed33", size = 5226646, upload-time = "2026-03-23T08:23:18.306Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/52/7308a033fa43b7e8e188797bd2b3b017c0f0adda70fa7af575b1f43ea888/prek-0.3.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f3d7fdadb15efc19c09953c7a33cf2061a70f367d1e1957358d3ad5cc49d0616", size = 5620104, upload-time = "2026-03-23T08:23:40.053Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/b1/f106ac000a91511a9cd80169868daf2f5b693480ef5232cec5517a38a512/prek-0.3.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:72728c3295e79ca443f8c1ec037d2a5b914ec73a358f69cf1bc1964511876bf8", size = 5199867, upload-time = "2026-03-23T08:23:38.066Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/e9/970713f4b019f69de9844e1bab37b8ddb67558e410916f4eb5869a696165/prek-0.3.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:48efc28f2f53b5b8087efca9daaed91572d62df97d5f24a1c7a087fecb5017de", size = 5441801, upload-time = "2026-03-23T08:23:32.617Z" },
-    { url = "https://files.pythonhosted.org/packages/12/a4/7ef44032b181753e19452ec3b09abb3a32607cf6b0a0508f0604becaaf2b/prek-0.3.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f6ca9d63bacbc448a5c18e955c78d3ac5176c3a17c3baacdd949b1a623e08a36", size = 5155107, upload-time = "2026-03-23T08:23:31.021Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/77/4d9c8985dbba84149760785dfe07093ea1e29d710257dfb7c89615e2234c/prek-0.3.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1000f7029696b4fe712fb1fefd4c55b9c4de72b65509c8e50296370a06f9dc3f", size = 5566541, upload-time = "2026-03-23T08:23:45.694Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/1a/81e6769ac1f7f8346d09ce2ab0b47cf06466acd9ff72e87e5d1f0d98cd32/prek-0.3.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6ff0bed0e2c1286522987d982168a86cbbd0d069d840506a46c9fda983515517", size = 6552991, upload-time = "2026-03-23T08:23:21.958Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/fa/ce2df0dd2dc75a9437a52463239d0782998943d7b04e191fb89b83016c34/prek-0.3.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4fb087ac0ffda3ac65bbbae9a38326a7fd27ee007bb4a94323ce1eb539d8bbec", size = 5832972, upload-time = "2026-03-23T08:23:20.258Z" },
-    { url = "https://files.pythonhosted.org/packages/18/6b/9d4269df9073216d296244595a21c253b6475dfc9076c0bd2906be7a436c/prek-0.3.8-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:2e1e5e206ff7b31bd079cce525daddc96cd6bc544d20dc128921ad92f7a4c85d", size = 5448371, upload-time = "2026-03-23T08:23:41.835Z" },
-    { url = "https://files.pythonhosted.org/packages/60/1d/1e4d8a78abefa5b9d086e5a9f1638a74b5e540eec8a648d9946707701f29/prek-0.3.8-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:dcea3fe23832a4481bccb7c45f55650cb233be7c805602e788bb7dba60f2d861", size = 5270546, upload-time = "2026-03-23T08:23:24.231Z" },
-    { url = "https://files.pythonhosted.org/packages/77/07/34f36551a6319ae36e272bea63a42f59d41d2d47ab0d5fb00eb7b4e88e87/prek-0.3.8-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:4d25e647e9682f6818ab5c31e7a4b842993c14782a6ffcd128d22b784e0d677f", size = 5124032, upload-time = "2026-03-23T08:23:26.368Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/01/6d544009bb655e709993411796af77339f439526db4f3b3509c583ad8eb9/prek-0.3.8-py3-none-musllinux_1_1_i686.whl", hash = "sha256:de528b82935e33074815acff3c7c86026754d1212136295bc88fe9c43b4231d5", size = 5432245, upload-time = "2026-03-23T08:23:47.877Z" },
-    { url = "https://files.pythonhosted.org/packages/54/96/1237ee269e9bfa283ffadbcba1f401f48a47aed2b2563eb1002740d6079d/prek-0.3.8-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:6d660f1c25a126e6d9f682fe61449441226514f412a4469f5d71f8f8cad56db2", size = 5950550, upload-time = "2026-03-23T08:23:43.8Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/6b/a574411459049bc691047c9912f375deda10c44a707b6ce98df2b658f0b3/prek-0.3.8-py3-none-win32.whl", hash = "sha256:b0c291c577615d9f8450421dff0b32bfd77a6b0d223ee4115a1f820cb636fdf1", size = 4949501, upload-time = "2026-03-23T08:23:16.338Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/b4/46b59fe49f635acd9f6530778ce577f9d8b49452835726a5311ffc902c67/prek-0.3.8-py3-none-win_amd64.whl", hash = "sha256:bc147fdbdd4ec33fc7a987b893ecb69b1413ac100d95c9889a70f3fd58c73d06", size = 5346551, upload-time = "2026-03-23T08:23:34.501Z" },
-    { url = "https://files.pythonhosted.org/packages/53/05/9cca1708bb8c65264124eb4b04251e0f65ce5bfc707080bb6b492d5a0df7/prek-0.3.8-py3-none-win_arm64.whl", hash = "sha256:a2614647aeafa817a5802ccb9561e92eedc20dcf840639a1b00826e2c2442515", size = 5190872, upload-time = "2026-03-23T08:23:29.463Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/78/b4149c8913ced2e42debb49e261c4788a1ce431e84226921c2e1a7ea8545/prek-0.4.8-py3-none-linux_armv6l.whl", hash = "sha256:1f8f8cdc65836b571824c965daebb81b449f7e4a43894c58621f5708d5a185ed", size = 5668955, upload-time = "2026-07-04T12:04:41.588Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5f/7f54a0087b6b2f1751aeb41266d9c15e66fd0055492814798ab818cd0414/prek-0.4.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:bce1798e96d9e3a6e6abf435da7107e81452f69edb3ca7c6f90a457355ea46e2", size = 6030947, upload-time = "2026-07-04T12:04:43.8Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d6/f2829fc3902920c36b764a386fa303e71a8219dac25cb3827c575e84199a/prek-0.4.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ab3a52db17254d701c3cebb7eea58c8230aa7c1959aacfd5b5f25de18edb15d1", size = 5572593, upload-time = "2026-07-04T12:04:45.763Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8c/c5589955bcd5e3e33b67d8bc3110818cecac82a38fd6bc8b5dfdc5de421c/prek-0.4.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:b3fcfd620523bbc3f51a21d7cd63449f659b9e2cf3582de12dd5949e23227b8f", size = 5847150, upload-time = "2026-07-04T12:04:47.419Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9d/1f2dc91bdb79d2c4714b27eac9477a51490fba5b4731330dbbebc76bd345/prek-0.4.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42e65bc8425e9d7f1691a13ca1da2e07807d1ba76c35740833354b945131689e", size = 5573738, upload-time = "2026-07-04T12:04:49.125Z" },
+    { url = "https://files.pythonhosted.org/packages/81/29/69a7b58e16ecbc5f3989bf4b028018d11a82dcdd320b93d6588d72f32aa7/prek-0.4.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f578492a8e0c9bc6b4bf6dfbba8716f647d4cd0769bf10ad6cf336e3096fd392", size = 5981054, upload-time = "2026-07-04T12:04:50.842Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cc/9b9850a60c22ed18c7755ebd2d72c6eefb37fac58149d09f6adc4691c2cf/prek-0.4.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4335f9d5beb123a3884a7fe34f57c9f0828f4fbb7666beab4298833459b104f", size = 6751350, upload-time = "2026-07-04T12:04:52.529Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18a8747df9c602e052881d3efb14dd7f7d62a59bd7277ae5171c9e7661d59d84", size = 6243881, upload-time = "2026-07-04T12:04:54.703Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/da/accd3ad07fd2891d3c2777eb42435439fdf11982c51d60f087c0b6b6e102/prek-0.4.8-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:4db639db481d5f854eff9b3d2108889e613b8c15868bcf6bdd777c7cee577436", size = 5848846, upload-time = "2026-07-04T12:04:56.402Z" },
+    { url = "https://files.pythonhosted.org/packages/15/00/3477704635249f21f5f98ce444cd7690c2aa9dc8d146a045db88ef2cd8c5/prek-0.4.8-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:c3890a6f92316d2cf44eb50584e8d2b23a596dd70487022e61186a71a2ac0900", size = 5713942, upload-time = "2026-07-04T12:04:58.311Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e6/3ca4fabaebeadc976d9a92d1d9130674265355ea3b728418bad61583b097/prek-0.4.8-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:fc7e15c24c591a37c6ffce5b25a021b16c299ac2649f183d812b67d665cd6551", size = 5554725, upload-time = "2026-07-04T12:04:59.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/46/2ab6aaaeff0cedb8955b2e4032071c8712382bdd423bb849718c3720180d/prek-0.4.8-py3-none-musllinux_1_1_i686.whl", hash = "sha256:36fe721704ff0c7624c1167639e23a5fe658bfd38c314f487219c9afd1eeb733", size = 5838595, upload-time = "2026-07-04T12:05:01.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8b/91398f2b6cd1629d5d8ca8c85b08eca500814a374313b0193f4aaf6ab6c4/prek-0.4.8-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:162e544abc394a8124f3a4ad68efee116bad09440e679dbd1675177335c2a432", size = 6357222, upload-time = "2026-07-04T12:05:03.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2a/ce5cbfaad36866134a21754640a05ecdba641fcd7ad15aa74cf3443f34f6/prek-0.4.8-py3-none-win32.whl", hash = "sha256:2602e46c8c5da7dfa69f60fcf88c2b57132ac623f49fb08bfb3094298c5f07e3", size = 5354388, upload-time = "2026-07-04T12:05:05.587Z" },
+    { url = "https://files.pythonhosted.org/packages/df/03/3bc908bc5f7e430315553e47dfa055f19923a3888f9afe4da19f244b5cbf/prek-0.4.8-py3-none-win_amd64.whl", hash = "sha256:7cb22da60bee41b89c4978c0bea7126a3c0ccc003dae6748cf29b53947815edc", size = 5748221, upload-time = "2026-07-04T12:05:07.559Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a7/4295e6d5f5028171dfeb115ad38ab76bf3fe0c8df91b70d73c79aa760a94/prek-0.4.8-py3-none-win_arm64.whl", hash = "sha256:da70057f577b15d4bd121bf9dd29ee205fd4b4d75a0cafba062e84d7e8b4378b", size = 5574425, upload-time = "2026-07-04T12:05:09.595Z" },
+]
+
+[[package]]
+name = "properdocs"
+version = "1.6.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/29/f27a4e1eddf72ed3db6e47818fbafe6debbf09fd7051f9c1a007239b46ef/properdocs-1.6.7.tar.gz", hash = "sha256:adc7b16e562890af0e098a7e5b02e3a81c20894a87d6a28d345c9300de73c26e", size = 276141, upload-time = "2026-03-20T20:07:48.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/4d/fc923f5c85318ee8cc903566dc4e0ebe41b2dfc1d2ecf5546db232397ed6/properdocs-1.6.7-py3-none-any.whl", hash = "sha256:6fa0cfa2e01bf338f684892c8a506cf70ea88ae7f3479c933b6fa20168101cbd", size = 225406, upload-time = "2026-03-20T20:07:46.875Z" },
 ]
 
 [[package]]
@@ -428,24 +446,24 @@ provides-extras = ["devel"]
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.19.1"
+version = "10.21.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/72/2d/9f30cee56d4d6d222430d401e85b0a6a1ae229819362f5786943d1a8c03b/pymdown_extensions-10.19.1.tar.gz", hash = "sha256:4969c691009a389fb1f9712dd8e7bd70dcc418d15a0faf70acb5117d022f7de8", size = 847839, upload-time = "2025-12-14T17:25:24.42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/35/b763e8fbcd51968329b9adc52d188fc97859f85f2ee15fe9f379987d99c5/pymdown_extensions-10.19.1-py3-none-any.whl", hash = "sha256:e8698a66055b1dc0dca2a7f2c9d0ea6f5faa7834a9c432e3535ab96c0c4e509b", size = 266693, upload-time = "2025-12-14T17:25:22.999Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
 ]
 
 [[package]]
@@ -512,7 +530,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.33.1"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -520,9 +538,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -545,11 +563,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Certificate functions accept `host:port`** - `Get-Certificate`, `Get-CertificateOpenSSL`, and the `Show-Certificate`/`Show-CertificateChain` wrappers now take a port embedded in the Uri (`example.com:8443`) or an explicit `-Port`, mirroring `openssl s_client -connect host:port`. New `Split-UriHostPort` helper parses scheme/userinfo/path/query/fragment/IPv6 forms.
- **Cleaner error handling** - failures now surface concise, categorized errors (`Failed to get certificate from '<host:port>'. <cause>`) via `$PSCmdlet.ThrowTerminatingError` instead of raw .NET exceptions, and TCP/SSL streams are disposed. The `Show-*` wrappers re-throw so errors report the user's call site, not the module internals.
- **Makefile** - adds `PREK_NATIVE_TLS` (MITM proxy trust), silences an upstream mkdocs deprecation warning, and adds `HOOK=<id>` single-hook support via a `PREK_RUN` macro.
- **Docs restructure** - slims `AGENTS.md` to a compound-knowledge index pointing at a new `ARCHITECTURE.md` (module system, hook inventory, build pipeline, skills) and `design/lessons.md`; documents the new certificate port usage.
- **New `second-opinion` skill** - heterogeneous-model code review via GitHub Copilot CLI, with a repo-specific review brief.

## Test plan

- [x] `make lint-diff` - all pre-commit hooks green
- [x] `uv run mkdocs build --strict` - builds with zero warnings
- [x] `Split-UriHostPort` verified across 11 URI shapes (bare host, host:port, scheme, userinfo, IPv6, query, fragment, combined)
- [x] `/second-opinion` (gpt-5.3-codex) - one bug found (query/fragment parsing) and fixed; verification rerun clean
- [ ] Reviewer: sanity-check `Get-Certificate example.com:8443 -BuildChain` against a real endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)