### PR TITLE
feat: aliases-git v1.24.0 - add -NoVerify switch to push aliases

### DIFF
--- a/modules/aliases-git/Functions/alias.ps1
+++ b/modules/aliases-git/Functions/alias.ps1
@@ -241,7 +241,9 @@ function gcv {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit --verbose' @PSBoundParameters
@@ -256,7 +258,9 @@ function gc! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit --verbose --amend' @PSBoundParameters
@@ -271,7 +275,9 @@ function gca {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit --verbose --all' @PSBoundParameters
@@ -286,13 +292,16 @@ function gcap {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     gca @PSBoundParameters
 
     $PSBoundParameters.Remove('Xargs') | Out-Null
-    gpush @PSBoundParameters
+    gpush @PSBoundParameters -NoVerify:$NoVerify
 }
 function gac {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -304,13 +313,16 @@ function gac {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     $PSBoundParameters.Remove('Xargs') | Out-Null
     gaa @PSBoundParameters
 
-    gcv -Xargs $Xargs @PSBoundParameters
+    gcv -Xargs $Xargs @PSBoundParameters -NoVerify:$NoVerify
 }
 function gacp {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -322,13 +334,16 @@ function gacp {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     gac @PSBoundParameters
 
     $PSBoundParameters.Remove('Xargs') | Out-Null
-    gpush @PSBoundParameters
+    gpush @PSBoundParameters -NoVerify:$NoVerify
 }
 function gca! {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -340,7 +355,9 @@ function gca! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit --verbose --all --amend' @PSBoundParameters
@@ -355,13 +372,16 @@ function gac! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     $PSBoundParameters.Remove('Xargs') | Out-Null
     gaa @PSBoundParameters
 
-    gca! -Xargs $Xargs @PSBoundParameters
+    gca! -Xargs $Xargs @PSBoundParameters -NoVerify:$NoVerify
 }
 function gcam {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -373,7 +393,9 @@ function gcam {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit --all -m' @PSBoundParameters
@@ -388,13 +410,16 @@ function gcamp {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     gcam @PSBoundParameters
 
     $PSBoundParameters.Remove('Xargs') | Out-Null
-    gpush @PSBoundParameters
+    gpush @PSBoundParameters -NoVerify:$NoVerify
 }
 function gacm {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -406,13 +431,16 @@ function gacm {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     $PSBoundParameters.Remove('Xargs') | Out-Null
     gaa @PSBoundParameters
 
-    gcmsg -Xargs $Xargs @PSBoundParameters
+    gcmsg -Xargs $Xargs @PSBoundParameters -NoVerify:$NoVerify
 }
 function gacmp {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -424,13 +452,16 @@ function gacmp {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     gacm @PSBoundParameters
 
     $PSBoundParameters.Remove('Xargs') | Out-Null
-    gpush @PSBoundParameters
+    gpush @PSBoundParameters -NoVerify:$NoVerify
 }
 function gcan! {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -442,7 +473,9 @@ function gcan! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit --verbose --all --no-edit --amend' @PSBoundParameters
@@ -457,13 +490,16 @@ function gcanp! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     gcan! @PSBoundParameters
 
     $PSBoundParameters.Remove('Xargs') | Out-Null
-    gpush! @PSBoundParameters
+    gpush! @PSBoundParameters -NoVerify:$NoVerify
 }
 function gcempty {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -475,7 +511,9 @@ function gcempty {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand 'git commit --allow-empty -m' @PSBoundParameters
@@ -490,13 +528,16 @@ function gacn! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     $PSBoundParameters.Remove('Xargs') | Out-Null
     gaa @PSBoundParameters
 
-    gcn! -Xargs $Xargs @PSBoundParameters
+    gcn! -Xargs $Xargs @PSBoundParameters -NoVerify:$NoVerify
 }
 function gacnp! {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -508,13 +549,16 @@ function gacnp! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     gacn! @PSBoundParameters
 
     $PSBoundParameters.Remove('Xargs') | Out-Null
-    gpush! @PSBoundParameters
+    gpush! @PSBoundParameters -NoVerify:$NoVerify
 }
 function gcns! {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -526,7 +570,9 @@ function gcns! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit --verbose --signoff --no-edit --amend' @PSBoundParameters
@@ -541,7 +587,9 @@ function gcans! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit --verbose --all --signoff --no-edit --amend' @PSBoundParameters
@@ -556,13 +604,16 @@ function gacns! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     $PSBoundParameters.Remove('Xargs') | Out-Null
     gaa @PSBoundParameters
 
-    gcns! -Xargs $Xargs @PSBoundParameters
+    gcns! -Xargs $Xargs @PSBoundParameters -NoVerify:$NoVerify
 }
 function gcmsg {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -574,7 +625,9 @@ function gcmsg {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit -m' @PSBoundParameters
@@ -589,13 +642,16 @@ function gcmsgp {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     gcmsg @PSBoundParameters
 
     $PSBoundParameters.Remove('Xargs') | Out-Null
-    gpush @PSBoundParameters
+    gpush @PSBoundParameters -NoVerify:$NoVerify
 }
 function gcn! {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -607,7 +663,9 @@ function gcn! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit --verbose --no-edit --amend' @PSBoundParameters
@@ -622,13 +680,16 @@ function gcnp! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
+    $PSBoundParameters.Remove('NoVerify') | Out-Null
     gcn! @PSBoundParameters
 
     $PSBoundParameters.Remove('Xargs') | Out-Null
-    gpush! @PSBoundParameters
+    gpush! @PSBoundParameters -NoVerify:$NoVerify
 }
 function gcsm {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -640,7 +701,9 @@ function gcsm {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git commit --signoff -m' @PSBoundParameters
@@ -1554,7 +1617,9 @@ function gpush {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git push' @PSBoundParameters
@@ -1569,7 +1634,9 @@ function gpush! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git push --force-with-lease' @PSBoundParameters
@@ -1584,7 +1651,9 @@ function gpushdr {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git push --dry-run' @PSBoundParameters
@@ -1603,12 +1672,16 @@ function gpushoat {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     if ($remote = @(git remote)[0]) {
         # calculate command string
-        $cmnd = "git push $remote --all && git push $remote --tags"
+        $nv = $NoVerify ? ' --no-verify' : ''
+        $cmnd = "git push $remote --all$nv && git push $remote --tags$nv"
+        $PSBoundParameters.Remove('NoVerify') | Out-Null
         # run command
         Invoke-WriteExecCommand -Command $cmnd @PSBoundParameters
     } else {
@@ -1625,7 +1698,9 @@ function gpushsup {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command "git push --set-upstream origin $(Get-GitCurrentBranch)" @PSBoundParameters
@@ -1640,7 +1715,9 @@ function gpusht {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git push --tags' @PSBoundParameters
@@ -1655,7 +1732,9 @@ function gpusht! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git push --tags --force' @PSBoundParameters
@@ -1670,7 +1749,9 @@ function gpushv {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     Invoke-WriteExecCommand -Command 'git push --verbose' @PSBoundParameters

--- a/modules/aliases-git/Functions/helper.ps1
+++ b/modules/aliases-git/Functions/helper.ps1
@@ -59,15 +59,18 @@ function gbdo {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     # calculate command strings
     if ($remote = @(git remote)[0]) {
         $commands = [System.Collections.Generic.List[string]]::new()
         $commands.Add("git branch --delete $Branch")
-        $commands.Add("git push --delete $remote $Branch")
+        $commands.Add("git push --delete $remote $Branch$($NoVerify ? ' --no-verify' : '')")
         $PSBoundParameters.Remove('Branch') | Out-Null
+        $PSBoundParameters.Remove('NoVerify') | Out-Null
     } else {
         Write-Host 'fatal: Remote repository not set.'
         return
@@ -92,15 +95,18 @@ function gbdo! {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     # calculate command strings
     if ($remote = @(git remote)[0]) {
         $commands = [System.Collections.Generic.List[string]]::new()
         $commands.Add("git branch -D $Branch")
-        $commands.Add("git push --delete $remote $Branch")
+        $commands.Add("git push --delete $remote $Branch$($NoVerify ? ' --no-verify' : '')")
         $PSBoundParameters.Remove('Branch') | Out-Null
+        $PSBoundParameters.Remove('NoVerify') | Out-Null
     } else {
         Write-Host 'fatal: Remote repository not set.'
         return
@@ -153,7 +159,9 @@ function gpushd {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     if ($remote = @(git remote)[0]) {
@@ -210,7 +218,9 @@ function gmgo {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     # calculate command strings
@@ -219,7 +229,9 @@ function gmgo {
         $currentBranch = git branch --show-current
         # resolve provided branch
         $resolvedBranch = Get-GitResolvedBranch $Branch
+        $nv = $NoVerify ? ' --no-verify' : ''
         $PSBoundParameters.Remove('Branch') | Out-Null
+        $PSBoundParameters.Remove('NoVerify') | Out-Null
         # build list of commands to execute
         Invoke-WriteExecCommand -Command "git fetch $remote --prune" @PSBoundParameters
         if ($currentBranch -ne $resolvedBranch) {
@@ -227,7 +239,7 @@ function gmgo {
         }
         Invoke-WriteExecCommand -Command "git merge ${remote}/${resolvedBranch}" @PSBoundParameters | Tee-Object -Variable merge
         if ($merge | Select-String 'Fast-forward' -Quiet) {
-            Invoke-WriteExecCommand -Command "git push ${remote}" @PSBoundParameters
+            Invoke-WriteExecCommand -Command "git push ${remote}${nv}" @PSBoundParameters
         }
     } else {
         Write-Host 'fatal: Remote repository not set.'
@@ -273,7 +285,9 @@ function grbo {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     # calculate command strings
@@ -282,7 +296,9 @@ function grbo {
         $currentBranch = git branch --show-current
         # resolve provided branch
         $resolvedBranch = Get-GitResolvedBranch $Branch
+        $nv = $NoVerify ? ' --no-verify' : ''
         $PSBoundParameters.Remove('Branch') | Out-Null
+        $PSBoundParameters.Remove('NoVerify') | Out-Null
         # build list of commands to execute
         $commands = [System.Collections.Generic.List[string]]::new()
         $commands.Add("git fetch $remote --prune")
@@ -302,7 +318,7 @@ function grbo {
     # check if rebase was successful and push changes
     $behind, $ahead = (git rev-list --count --left-right '@{u}...HEAD') -split "`t"
     if ($? -and $behind -eq 0 -and $ahead -gt 0) {
-        Invoke-WriteExecCommand -Command "git push ${remote}" @PSBoundParameters
+        Invoke-WriteExecCommand -Command "git push ${remote}${nv}" @PSBoundParameters
     }
 }
 function gmb {

--- a/modules/aliases-git/Functions/internal.ps1
+++ b/modules/aliases-git/Functions/internal.ps1
@@ -217,6 +217,10 @@ Command arguments to be passed to the provided command.
 Do not execute the command.
 .PARAMETER Quiet
 Do not print the command string.
+.PARAMETER NoVerify
+Append --no-verify after all arguments to skip git hooks (pre-commit/pre-push).
+Not compatible with a '--' pathspec on commit (git treats trailing args as
+pathspecs); in that rare case pass --no-verify manually before the '--'.
 #>
 function Invoke-WriteExecCommand {
     [CmdletBinding(DefaultParameterSetName = 'Default')]
@@ -231,7 +235,9 @@ function Invoke-WriteExecCommand {
         [switch]$WhatIf,
 
         [Parameter(ParameterSetName = 'quiet')]
-        [switch]$Quiet
+        [switch]$Quiet,
+
+        [switch]$NoVerify
     )
 
     begin {
@@ -242,6 +248,10 @@ function Invoke-WriteExecCommand {
                 $arg = $_ -match '\s|@' ? "'$_'" : $_
                 $sb.Append(" $arg") | Out-Null
             }
+        }
+        # append --no-verify after all arguments (correct position for both push and -m commit)
+        if ($NoVerify) {
+            $sb.Append(' --no-verify') | Out-Null
         }
         # get command string
         $cmnd = $sb.ToString()

--- a/modules/aliases-git/aliases-git.psd1
+++ b/modules/aliases-git/aliases-git.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'aliases-git.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '1.23.1'
+    ModuleVersion        = '1.24.0'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Core')

--- a/uv.lock
+++ b/uv.lock
@@ -26,11 +26,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2026.6.17"
+version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]
@@ -368,11 +368,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.10.0"
+version = "4.11.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz", hash = "sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0", size = 31953, upload-time = "2026-07-21T13:09:36.565Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl", hash = "sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74", size = 23247, upload-time = "2026-07-21T13:09:35.422Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add a `-NoVerify` switch to every `aliases-git` function that runs `git push` **or** `git commit`, appending `--no-verify` to skip the corresponding hooks (pre-push / pre-commit). Chosen over name-encoded variants (`gpushnv`, `gcmsgnvp`, ...) to avoid a combinatorial explosion of alias names - one orthogonal switch instead.
- **Semantics:** the switch targets the *last command in the chain*. `gcam -NoVerify` skips the commit hook; `gcamp -NoVerify` skips the push hook; `gcamp 'msg' --no-verify -NoVerify` does both (raw `--no-verify` flows to the commit, switch to the push).
- **Centralized in the helper:** `Invoke-WriteExecCommand` gained the `-NoVerify` switch and appends `--no-verify` *after* all arguments - the correct position for both `git push` and `git commit -m 'msg'` (must follow the message). Single-command aliases just declare the switch and splat; no per-function string-building.
- Multi-command functions (`gpushoat`, `gmgo`, `grbo`, `gbdo`, `gbdo!`) keep embedding `--no-verify` on the specific push, since a blanket append would wrongly hit a sibling `fetch`/`merge`/`branch --delete`.
- Combos/wrappers forward `-NoVerify` to the right sub-command (inner commit vs. push).
- Bump `aliases-git` `ModuleVersion` 1.23.1 -> 1.24.0 (MINOR: new backward-compatible capability).
- `chore: bump dependencies` - routine `uv.lock` refresh (certifi, platformdirs).

## Test plan

- [x] `make lint-diff` - all pre-commit hooks green
- [x] Module parses clean (`[Parser]::ParseFile`) and imports without error
- [x] `-WhatIf` smoke tests across all categories confirm correct `--no-verify` placement:
  - `gcmsg 'msg' -NoVerify` -> `git commit -m 'msg' --no-verify` (after the message)
  - `gpush -NoVerify` -> `git push --no-verify`
  - `gcamp 'msg' -NoVerify` -> commit clean, `git push --no-verify` (last-in-chain)
  - `gcamp 'msg' --no-verify -NoVerify` -> both commit and push get `--no-verify`
  - `gpushoat -NoVerify` -> `--no-verify` on both push legs of the `&&`
- [ ] Reviewer: sanity-check the helper-level append vs. the multi-command manual paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)